### PR TITLE
Implement workaround for not saving list scroll state and various fixes

### DIFF
--- a/app/src/main/kotlin/net/primal/android/MainActivity.kt
+++ b/app/src/main/kotlin/net/primal/android/MainActivity.kt
@@ -4,6 +4,7 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
@@ -15,9 +16,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import net.primal.android.navigation.PrimalAppNavigation
-import net.primal.android.theme.defaultPrimalTheme
+import net.primal.android.theme.PrimalRippleTheme
 import net.primal.android.theme.PrimalTheme
 import net.primal.android.theme.active.ActiveThemeStore
+import net.primal.android.theme.defaultPrimalTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -41,6 +43,7 @@ class MainActivity : ComponentActivity() {
             ) {
                 CompositionLocalProvider(
                     LocalPrimalTheme provides primalTheme,
+                    LocalRippleTheme provides PrimalRippleTheme,
                 ) {
                     PrimalAppNavigation()
                 }

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/CardWithHighlight.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/CardWithHighlight.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -37,7 +39,7 @@ fun CardWithHighlight(
     )
 
     Card(
-        modifier = modifier,
+        modifier = modifier.clip(CardDefaults.shape),
     ) {
         if (highlighted || connected) {
             Column(

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostContent.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostContent.kt
@@ -85,7 +85,7 @@ private fun String.replaceNostrProfileUrisWithHandles(
         checkNotNull(it.referencedUser)
         newContent = newContent.replace(
             oldValue = it.uri,
-            newValue = it.referencedUser.displayHandle,
+            newValue = it.referencedUser.displayUsername,
             ignoreCase = true
         )
     }
@@ -165,7 +165,7 @@ fun FeedPostContent(
 
             referencedUserResources.forEach {
                 checkNotNull(it.referencedUser)
-                val displayHandle = it.referencedUser.displayHandle
+                val displayHandle = it.referencedUser.displayUsername
                 val startIndex = refinedContent.indexOf(displayHandle)
                 if (startIndex >= 0) {
                     val endIndex = startIndex + displayHandle.length

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostList.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostList.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,10 +28,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.paging.PagingData
-import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapNotNull
@@ -50,7 +47,8 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun FeedPostList(
-    posts: Flow<PagingData<FeedPostUi>>,
+    feedListState: LazyListState,
+    pagingItems: LazyPagingItems<FeedPostUi>,
     walletConnected: Boolean,
     onPostClick: (String) -> Unit,
     onProfileClick: (String) -> Unit,
@@ -65,13 +63,11 @@ fun FeedPostList(
     zapOptions: List<ULong>? = null,
     syncStats: FeedPostsSyncStats = FeedPostsSyncStats(),
     paddingValues: PaddingValues = PaddingValues(0.dp),
-    feedListState: LazyListState = rememberLazyListState(),
     bottomBarHeightPx: Float = 0F,
     bottomBarOffsetHeightPx: Float = 0F,
     onScrolledToTop: (() -> Unit)? = null,
 ) {
     val uiScope = rememberCoroutineScope()
-    val pagingItems = posts.collectAsLazyPagingItems()
 
     val seenPostIds = remember { mutableSetOf<String>() }
     LaunchedEffect(feedListState) {

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostList.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostList.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -32,14 +31,12 @@ import androidx.paging.compose.LazyPagingItems
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import net.primal.android.R
 import net.primal.android.core.compose.AvatarThumbnailsRow
 import net.primal.android.core.compose.feed.model.FeedPostUi
 import net.primal.android.core.compose.feed.model.FeedPostsSyncStats
 import net.primal.android.core.compose.foundation.brandBackground
-import net.primal.android.core.compose.isEmpty
 import net.primal.android.theme.AppTheme
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
@@ -69,35 +66,16 @@ fun FeedPostList(
 ) {
     val uiScope = rememberCoroutineScope()
 
-    val seenPostIds = remember { mutableSetOf<String>() }
-    LaunchedEffect(feedListState) {
-        snapshotFlow { feedListState.layoutInfo.visibleItemsInfo }
-            .mapNotNull { visibleItems ->
-                visibleItems.mapNotNull {
-                    if (!pagingItems.isEmpty() && it.index < pagingItems.itemCount) {
-                        pagingItems.peek(it.index)?.postId
-                    } else {
-                        null
-                    }
-                }
-            }
-            .distinctUntilChanged()
-            .collect {
-                seenPostIds.addAll(it)
-            }
-    }
-
-    val newPostsCount = syncStats.postsCount
-
     LaunchedEffect(feedListState) {
         snapshotFlow { feedListState.firstVisibleItemIndex == 0 }
             .distinctUntilChanged()
             .filter { it }
             .collect {
-                seenPostIds.clear()
                 onScrolledToTop?.invoke()
             }
     }
+
+    val newPostsCount = syncStats.postsCount
 
     LaunchedEffect(pagingItems) {
         while (true) {

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostListItem.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostListItem.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalContext
@@ -57,7 +56,6 @@ import net.primal.android.theme.PrimalTheme
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun FeedPostListItem(
     data: FeedPostUi,

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostStatsRow.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/FeedPostStatsRow.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -133,6 +135,7 @@ private fun SinglePostStat(
 
     Text(
         modifier = Modifier
+            .clip(CircleShape)
             .animateContentSize()
             .combinedClickable(
                 onClick = onClick,

--- a/app/src/main/kotlin/net/primal/android/core/compose/foundation/RememberLazyListState.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/foundation/RememberLazyListState.kt
@@ -1,0 +1,22 @@
+package net.primal.android.core.compose.foundation
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.paging.compose.LazyPagingItems
+
+@Composable
+fun <T : Any> LazyPagingItems<T>.rememberLazyListStatePagingWorkaround(): LazyListState {
+    // After recreation, LazyPagingItems first return 0 items, then the cached items.
+    // This behavior/issue is resetting the LazyListState scroll position.
+    // Below is a workaround. More info:
+    // https://issuetracker.google.com/issues/177245496
+    // https://issuetracker.google.com/issues/179397301
+    return when (itemCount) {
+        // Return a different LazyListState instance.
+        0 -> remember(this) { LazyListState(0, 0) }
+        // Return rememberLazyListState (normal case).
+        else -> rememberLazyListState()
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/core/utils/ProfileNameUtils.kt
+++ b/app/src/main/kotlin/net/primal/android/core/utils/ProfileNameUtils.kt
@@ -25,16 +25,16 @@ fun ProfileMetadata.authorNameUiFriendly(userId: String): String =
 
 private fun authorNameUiFriendly(displayName: String?, name: String?, pubkey: String): String {
     return when {
-        displayName?.isNotEmpty() == true -> displayName
-        name?.isNotEmpty() == true -> name
+        displayName?.isNotBlank() == true -> displayName
+        name?.isNotBlank() == true -> name
         else -> pubkey.asEllipsizedNpub()
     }
 }
 
 private fun usernameUiFriendly(displayName: String?, name: String?, pubkey: String): String {
     return when {
-        name?.isNotEmpty() == true -> name
-        displayName?.isNotEmpty() == true -> displayName
+        name?.isNotBlank() == true -> name
+        displayName?.isNotBlank() == true -> displayName
         else -> pubkey.asEllipsizedNpub()
     }
 }

--- a/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
@@ -34,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import net.primal.android.R
@@ -42,6 +42,7 @@ import net.primal.android.core.compose.PrimalTopAppBar
 import net.primal.android.core.compose.PrimalTopLevelDestination
 import net.primal.android.core.compose.feed.FeedPostList
 import net.primal.android.core.compose.foundation.brandBackground
+import net.primal.android.core.compose.foundation.rememberLazyListStatePagingWorkaround
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.AvatarDefault
 import net.primal.android.core.compose.icons.primaliconpack.FeedPicker
@@ -100,7 +101,9 @@ fun FeedScreen(
 ) {
     val uiScope = rememberCoroutineScope()
     val drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed)
-    val feedListState = rememberLazyListState()
+
+    val feedPagingItems = state.posts.collectAsLazyPagingItems()
+    val feedListState = feedPagingItems.rememberLazyListStatePagingWorkaround()
 
     val bottomBarHeight = PrimalBottomBarHeightDp
     var bottomBarOffsetHeightPx by remember { mutableFloatStateOf(0f) }
@@ -142,7 +145,8 @@ fun FeedScreen(
         },
         content = { paddingValues ->
             FeedPostList(
-                posts = state.posts,
+                pagingItems = feedPagingItems,
+                feedListState = feedListState,
                 walletConnected = state.walletConnected,
                 onPostClick = onPostClick,
                 onProfileClick = onProfileClick,
@@ -184,7 +188,6 @@ fun FeedScreen(
                 zapOptions = state.zapOptions,
                 syncStats = state.syncStats,
                 paddingValues = paddingValues,
-                feedListState = feedListState,
                 bottomBarHeightPx = with(LocalDensity.current) {
                     bottomBarHeight.roundToPx().toFloat()
                 },

--- a/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
@@ -1,6 +1,5 @@
 package net.primal.android.explore.feed
 
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
@@ -17,11 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.launch
 import net.primal.android.R
 import net.primal.android.core.compose.AppBarIcon
 import net.primal.android.core.compose.PrimalTopAppBar
 import net.primal.android.core.compose.feed.FeedPostList
+import net.primal.android.core.compose.foundation.rememberLazyListStatePagingWorkaround
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.ArrowBack
 import net.primal.android.core.compose.icons.primaliconpack.UserFeedAdd
@@ -69,7 +70,9 @@ fun ExploreFeedScreen(
 ) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-    val listState = rememberLazyListState()
+
+    val feedPagingItems = state.posts.collectAsLazyPagingItems()
+    val feedListState = feedPagingItems.rememberLazyListStatePagingWorkaround()
 
     val uiScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -121,10 +124,10 @@ fun ExploreFeedScreen(
         },
         content = { paddingValues ->
             FeedPostList(
-                posts = state.posts,
+                feedListState = feedListState,
+                pagingItems = feedPagingItems,
                 walletConnected = state.walletConnected,
                 paddingValues = paddingValues,
-                feedListState = listState,
                 onPostClick = onPostClick,
                 onProfileClick = onProfileClick,
                 onPostReplyClick = {

--- a/app/src/main/kotlin/net/primal/android/feed/db/ReferencedUser.kt
+++ b/app/src/main/kotlin/net/primal/android/feed/db/ReferencedUser.kt
@@ -7,5 +7,5 @@ data class ReferencedUser(
     val userId: String,
     val handle: String,
 ) {
-    val displayHandle get() = "@$handle"
+    val displayUsername get() = "@$handle"
 }

--- a/app/src/main/kotlin/net/primal/android/feed/repository/FeedRepository.kt
+++ b/app/src/main/kotlin/net/primal/android/feed/repository/FeedRepository.kt
@@ -100,6 +100,8 @@ class FeedRepository @Inject constructor(
         Pager(
             config = PagingConfig(
                 pageSize = 25,
+                prefetchDistance = 50,
+                initialLoadSize = 125,
                 enablePlaceholders = true,
             ),
             remoteMediator = FeedRemoteMediator(

--- a/app/src/main/kotlin/net/primal/android/feed/repository/FeedRepository.kt
+++ b/app/src/main/kotlin/net/primal/android/feed/repository/FeedRepository.kt
@@ -100,7 +100,7 @@ class FeedRepository @Inject constructor(
         Pager(
             config = PagingConfig(
                 pageSize = 25,
-                enablePlaceholders = false
+                enablePlaceholders = true,
             ),
             remoteMediator = FeedRemoteMediator(
                 feedDirective = feedDirective,

--- a/app/src/main/kotlin/net/primal/android/nostr/ext/NostrResources.kt
+++ b/app/src/main/kotlin/net/primal/android/nostr/ext/NostrResources.kt
@@ -2,6 +2,7 @@ package net.primal.android.nostr.ext
 
 import net.primal.android.core.utils.asEllipsizedNpub
 import net.primal.android.core.utils.authorNameUiFriendly
+import net.primal.android.core.utils.usernameUiFriendly
 import net.primal.android.crypto.bechToBytes
 import net.primal.android.crypto.toHex
 import net.primal.android.feed.db.NostrResource
@@ -128,7 +129,8 @@ fun List<PostData>.flatMapAsPostNostrResourcePO(
                 uri = link,
                 referencedUser = if (refUserProfileId != null) ReferencedUser(
                     userId = refUserProfileId,
-                    handle = profileIdToProfileDataMap[refUserProfileId]?.handle
+                    handle = profileIdToProfileDataMap[refUserProfileId]
+                        ?.usernameUiFriendly()
                         ?: refUserProfileId.asEllipsizedNpub(),
                 ) else null,
                 referencedPost = if (refPost != null && refPostAuthor != null) ReferencedPost(

--- a/app/src/main/kotlin/net/primal/android/notifications/repository/NotificationRepository.kt
+++ b/app/src/main/kotlin/net/primal/android/notifications/repository/NotificationRepository.kt
@@ -50,7 +50,12 @@ class NotificationRepository @Inject constructor(
     private fun createPager(
         pagingSourceFactory: () -> PagingSource<Int, Notification>,
     ) = Pager(
-        config = PagingConfig(pageSize = 50, enablePlaceholders = true),
+        config = PagingConfig(
+            pageSize = 50,
+            prefetchDistance = 100,
+            initialLoadSize = 200,
+            enablePlaceholders = true,
+        ),
         remoteMediator = remoteMediator,
         pagingSourceFactory = pagingSourceFactory,
     )

--- a/app/src/main/kotlin/net/primal/android/notifications/repository/NotificationRepository.kt
+++ b/app/src/main/kotlin/net/primal/android/notifications/repository/NotificationRepository.kt
@@ -50,7 +50,7 @@ class NotificationRepository @Inject constructor(
     private fun createPager(
         pagingSourceFactory: () -> PagingSource<Int, Notification>,
     ) = Pager(
-        config = PagingConfig(pageSize = 50, enablePlaceholders = false),
+        config = PagingConfig(pageSize = 50, enablePlaceholders = true),
         remoteMediator = remoteMediator,
         pagingSourceFactory = pagingSourceFactory,
     )

--- a/app/src/main/kotlin/net/primal/android/profile/details/ProfileScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/details/ProfileScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.ripple.rememberRipple
@@ -92,6 +91,7 @@ import net.primal.android.core.compose.NostrUserText
 import net.primal.android.core.compose.button.PrimalFilledButton
 import net.primal.android.core.compose.button.PrimalOutlinedButton
 import net.primal.android.core.compose.feed.FeedLazyColumn
+import net.primal.android.core.compose.foundation.rememberLazyListStatePagingWorkaround
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.ArrowBack
 import net.primal.android.core.compose.icons.primaliconpack.ContextShare
@@ -190,7 +190,9 @@ fun ProfileScreen(
 
     val topBarTitleVisible = rememberSaveable { mutableStateOf(false) }
     val coverTransparency = rememberSaveable { mutableFloatStateOf(0f) }
-    val listState = rememberLazyListState()
+
+    val pagingItems = state.authoredPosts.collectAsLazyPagingItems()
+    val listState = pagingItems.rememberLazyListStatePagingWorkaround()
 
     val snackbarHostState = remember { SnackbarHostState() }
     ErrorHandler(
@@ -230,7 +232,6 @@ fun ProfileScreen(
 
     Surface {
         Box {
-            val pagingItems = state.authoredPosts.collectAsLazyPagingItems()
             FeedLazyColumn(
                 contentPadding = PaddingValues(0.dp),
                 pagingItems = pagingItems,

--- a/app/src/main/kotlin/net/primal/android/theme/PrimalRippleTheme.kt
+++ b/app/src/main/kotlin/net/primal/android/theme/PrimalRippleTheme.kt
@@ -1,0 +1,19 @@
+package net.primal.android.theme
+
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material.ripple.RippleTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import net.primal.android.LocalPrimalTheme
+
+object PrimalRippleTheme : RippleTheme {
+
+    @Composable
+    override fun defaultColor(): Color = AppTheme.colorScheme.outline
+
+    @Composable
+    override fun rippleAlpha(): RippleAlpha = RippleTheme.defaultRippleAlpha(
+        contentColor = AppTheme.colorScheme.outline,
+        lightTheme = !LocalPrimalTheme.current.isDarkTheme
+    )
+}


### PR DESCRIPTION
Implemented rememberLazyListStatePagingWorkaround for bugs in the paging/compose libraries which are causing list state to be lost on configuration changes. Enabled placeholders are part of the workaround for feed and notifications list;

Removed seenPostIds snapshotFlow from FeedPostList which is not used anywhere. 

Customized paging config for feed and notifications list to improve scrolling;

Implemented PrimalRippleTheme to change ripple color effects. 