### PR TITLE
Accessibility incorrectly labeled buttons

### DIFF
--- a/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
@@ -311,7 +311,7 @@ private fun AttachmentLoadingError() {
     ) {
         Icon(
             imageVector = Icons.Filled.Warning,
-            contentDescription = null,
+            contentDescription = stringResource(id = R.string.accessibility_warning),
             modifier = Modifier.size(48.dp),
         )
     }

--- a/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
@@ -132,7 +132,11 @@ fun MediaGalleryScreen(
             CenterAlignedTopAppBar(
                 title = {},
                 navigationIcon = {
-                    AppBarIcon(icon = PrimalIcons.ArrowBack, onClick = onClose)
+                    AppBarIcon(
+                        icon = PrimalIcons.ArrowBack,
+                        onClick = onClose,
+                        appBarIconContentDescription = stringResource(id = R.string.accessibility_back_button),
+                    )
                 },
                 colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = AppTheme.colorScheme.surface.copy(alpha = 0.2f),

--- a/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
@@ -189,7 +189,7 @@ private fun GalleryDropdownMenu(onSaveClick: () -> Unit) {
     AppBarIcon(
         icon = PrimalIcons.More,
         onClick = { menuVisible = true },
-        contentDescription = stringResource(id = R.string.accessibility_media_drop_down),
+        appBarIconContentDescription = stringResource(id = R.string.accessibility_media_drop_down),
     )
 
     DropdownPrimalMenu(

--- a/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/attachments/gallery/MediaGalleryScreen.kt
@@ -189,6 +189,7 @@ private fun GalleryDropdownMenu(onSaveClick: () -> Unit) {
     AppBarIcon(
         icon = PrimalIcons.More,
         onClick = { menuVisible = true },
+        contentDescription = stringResource(id = R.string.accessibility_media_drop_down),
     )
 
     DropdownPrimalMenu(

--- a/app/src/main/kotlin/net/primal/android/auth/create/ui/CreateAccountScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/auth/create/ui/CreateAccountScreen.kt
@@ -98,6 +98,7 @@ fun CreateAccountScreen(
                     } else {
                         PrimalIcons.ArrowBack
                     },
+                    navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                     onNavigationIconClick = {
                         if (state.currentStep == CreateAccountStep.NEW_ACCOUNT) {
                             onClose()

--- a/app/src/main/kotlin/net/primal/android/auth/login/LoginScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/auth/login/LoginScreen.kt
@@ -90,6 +90,7 @@ fun LoginScreen(
                 title = stringResource(id = R.string.login_title),
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
             )
         },
         content = { paddingValues ->

--- a/app/src/main/kotlin/net/primal/android/core/compose/AppBarIcon.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/AppBarIcon.kt
@@ -34,6 +34,7 @@ fun AppBarIcon(
     tint: Color = LocalContentColor.current,
     enabledBackgroundColor: Color = Color.Unspecified,
     disabledBackgroundColor: Color = AppTheme.colorScheme.outline,
+    contentDescription: String? = null,
 ) {
     IconButton(
         modifier = modifier
@@ -47,7 +48,7 @@ fun AppBarIcon(
         Icon(
             modifier = Modifier.size(24.dp),
             imageVector = icon,
-            contentDescription = null,
+            contentDescription = contentDescription,
             tint = tint,
         )
     }

--- a/app/src/main/kotlin/net/primal/android/core/compose/AppBarIcon.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/AppBarIcon.kt
@@ -34,7 +34,7 @@ fun AppBarIcon(
     tint: Color = LocalContentColor.current,
     enabledBackgroundColor: Color = Color.Unspecified,
     disabledBackgroundColor: Color = AppTheme.colorScheme.outline,
-    contentDescription: String? = null,
+    appBarIconContentDescription: String? = null,
 ) {
     IconButton(
         modifier = modifier
@@ -48,7 +48,7 @@ fun AppBarIcon(
         Icon(
             modifier = Modifier.size(24.dp),
             imageVector = icon,
-            contentDescription = contentDescription,
+            contentDescription = appBarIconContentDescription,
             tint = tint,
         )
     }

--- a/app/src/main/kotlin/net/primal/android/core/compose/AvatarThumbnailListItemImage.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/AvatarThumbnailListItemImage.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
@@ -22,6 +23,7 @@ import net.primal.android.attachments.domain.CdnImage
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.AvatarDefault
 import net.primal.android.theme.AppTheme
+import net.primal.android.R
 
 @Composable
 fun AvatarThumbnail(
@@ -62,7 +64,7 @@ private fun AvatarThumbnailListItemImage(
                 borderColor = borderColor,
             )
             .clickable(enabled = onClick != null, onClick = { onClick?.invoke() }),
-        contentDescription = null,
+        contentDescription = stringResource(id = R.string.accessibility_profile_image),
         contentScale = ContentScale.Crop,
         loading = {
             Box(

--- a/app/src/main/kotlin/net/primal/android/core/compose/DeleteListItemImage.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/DeleteListItemImage.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import net.primal.android.R
 import net.primal.android.theme.AppTheme
 
 @Composable
@@ -30,7 +32,7 @@ fun DeleteListItemImage(modifier: Modifier = Modifier, isRemovable: Boolean = tr
 
         Image(
             imageVector = Icons.Outlined.RemoveCircle,
-            contentDescription = null,
+            contentDescription = stringResource(id = R.string.accessibility_delete_list_item),
             colorFilter = ColorFilter.tint(
                 color = if (isRemovable) {
                     AppTheme.colorScheme.error

--- a/app/src/main/kotlin/net/primal/android/core/compose/DemoSecondaryScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/DemoSecondaryScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.ArrowBack
+import net.primal.android.R
+import androidx.compose.ui.res.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,6 +29,7 @@ fun DemoSecondaryScreen(
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
                 title = title,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
             )
         },
         content = { paddingValues ->

--- a/app/src/main/kotlin/net/primal/android/core/compose/PrimalNavigationBar.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/PrimalNavigationBar.kt
@@ -225,7 +225,7 @@ fun PrimalNavigationBarLightningBolt(
                 Icon(
                     modifier = Modifier.size(32.dp),
                     imageVector = imageVector,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.primary_destination_wallet_label),
                     tint = tint,
                 )
             }

--- a/app/src/main/kotlin/net/primal/android/core/compose/PrimalTopAppBar.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/PrimalTopAppBar.kt
@@ -45,6 +45,7 @@ fun PrimalTopAppBar(
     textColor: Color = LocalContentColor.current,
     navigationIcon: ImageVector? = null,
     navigationIconTintColor: Color = LocalContentColor.current,
+    navigationIconContentDescription: String? = null,
     autoCloseKeyboardOnNavigationIconClick: Boolean = true,
     avatarCdnImage: CdnImage? = null,
     actions: (@Composable RowScope.() -> Unit)? = null,
@@ -85,6 +86,7 @@ fun PrimalTopAppBar(
                             onNavigationIconClick()
                         },
                         tint = navigationIconTintColor,
+                        contentDescription = navigationIconContentDescription,
                     )
                 }
             },

--- a/app/src/main/kotlin/net/primal/android/core/compose/PrimalTopAppBar.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/PrimalTopAppBar.kt
@@ -86,7 +86,7 @@ fun PrimalTopAppBar(
                             onNavigationIconClick()
                         },
                         tint = navigationIconTintColor,
-                        contentDescription = navigationIconContentDescription,
+                        appBarIconContentDescription = navigationIconContentDescription,
                     )
                 }
             },

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/note/NoteDropdownMenu.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/note/NoteDropdownMenu.kt
@@ -58,7 +58,7 @@ fun NoteDropdownMenuIcon(
         Icon(
             modifier = Modifier.wrapContentSize(align = Alignment.TopEnd),
             imageVector = PrimalIcons.More,
-            contentDescription = null,
+            contentDescription = stringResource(id = R.string.accessibility_note_drop_down),
         )
 
         DropdownPrimalMenu(

--- a/app/src/main/kotlin/net/primal/android/core/compose/feed/note/NoteStatsRow.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/feed/note/NoteStatsRow.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.buildAnnotatedString
@@ -36,6 +37,7 @@ import net.primal.android.core.compose.icons.primaliconpack.FeedRepostsFilled
 import net.primal.android.core.compose.icons.primaliconpack.FeedZaps
 import net.primal.android.core.compose.icons.primaliconpack.FeedZapsFilled
 import net.primal.android.theme.AppTheme
+import net.primal.android.R
 
 @Composable
 fun FeedNoteStatsRow(
@@ -60,6 +62,7 @@ fun FeedNoteStatsRow(
             onLongClick = onPostLongPressAction?.let {
                 { onPostLongPressAction(FeedPostAction.Reply) }
             },
+            iconContentDescription = stringResource(id = R.string.accessibility_replies_count),
         )
 
         SinglePostStat(
@@ -74,6 +77,7 @@ fun FeedNoteStatsRow(
             onLongClick = onPostLongPressAction?.let {
                 { onPostLongPressAction(FeedPostAction.Zap) }
             },
+            iconContentDescription = stringResource(id = R.string.accessibility_zaps_count),
         )
 
         SinglePostStat(
@@ -90,6 +94,7 @@ fun FeedNoteStatsRow(
             onLongClick = onPostLongPressAction?.let {
                 { onPostLongPressAction(FeedPostAction.Like) }
             },
+            iconContentDescription = stringResource(id = R.string.accessibility_likes_count),
         )
 
         SinglePostStat(
@@ -104,6 +109,7 @@ fun FeedNoteStatsRow(
             onLongClick = onPostLongPressAction?.let {
                 { onPostLongPressAction(FeedPostAction.Repost) }
             },
+            iconContentDescription = stringResource(id = R.string.accessibility_repost_count),
         )
     }
 }
@@ -118,6 +124,7 @@ private fun SinglePostStat(
     colorHighlight: Color,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
+    iconContentDescription: String? = null,
 ) {
     val titleText = buildAnnotatedString {
         appendInlineContent("icon", "[icon]")
@@ -137,7 +144,7 @@ private fun SinglePostStat(
             ) {
                 Image(
                     imageVector = if (!highlighted) iconVector else iconVectorHighlight,
-                    contentDescription = null,
+                    contentDescription = iconContentDescription,
                     colorFilter = if (!highlighted) {
                         ColorFilter.tint(color = AppTheme.extraColorScheme.onSurfaceVariantAlt4)
                     } else {

--- a/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
@@ -161,6 +161,7 @@ fun FeedScreen(
                     AppBarIcon(
                         icon = PrimalIcons.FeedPicker,
                         onClick = onFeedsClick,
+                        contentDescription = stringResource(id = R.string.accessibility_feed_picker),
                     )
                 },
                 scrollBehavior = it,

--- a/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
@@ -246,7 +246,7 @@ fun FeedScreen(
                 content = {
                     Icon(
                         imageVector = Icons.Outlined.Add,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.accessibility_new_post),
                         tint = Color.White,
                     )
                 },

--- a/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/discuss/feed/FeedScreen.kt
@@ -161,7 +161,7 @@ fun FeedScreen(
                     AppBarIcon(
                         icon = PrimalIcons.FeedPicker,
                         onClick = onFeedsClick,
-                        contentDescription = stringResource(id = R.string.accessibility_feed_picker),
+                        appBarIconContentDescription = stringResource(id = R.string.accessibility_feed_picker),
                     )
                 },
                 scrollBehavior = it,

--- a/app/src/main/kotlin/net/primal/android/drawer/PrimalDrawer.kt
+++ b/app/src/main/kotlin/net/primal/android/drawer/PrimalDrawer.kt
@@ -162,7 +162,7 @@ private fun DrawerHeader(userAccount: UserAccount?) {
             onClick = {
             },
         ) {
-            Icon(imageVector = PrimalIcons.QrCode, contentDescription = null)
+            Icon(imageVector = PrimalIcons.QrCode, contentDescription = stringResource(id = R.string.accessibility_qr_code))
         }
 
         Text(

--- a/app/src/main/kotlin/net/primal/android/drawer/PrimalDrawer.kt
+++ b/app/src/main/kotlin/net/primal/android/drawer/PrimalDrawer.kt
@@ -264,7 +264,7 @@ private fun DrawerFooter(onThemeSwitch: () -> Unit) {
         IconButton(
             onClick = onThemeSwitch,
         ) {
-            Icon(imageVector = iconVector, contentDescription = null)
+            Icon(imageVector = iconVector, contentDescription = stringResource(id = R.string.accessibility_toggle_between_dark_and_light_mode))
         }
     }
 }

--- a/app/src/main/kotlin/net/primal/android/editor/ui/MiniFloatingIconButton.kt
+++ b/app/src/main/kotlin/net/primal/android/editor/ui/MiniFloatingIconButton.kt
@@ -20,6 +20,7 @@ fun MiniFloatingIconButton(
     modifier: Modifier,
     imageVector: ImageVector,
     onClick: () -> Unit,
+    floatingButtonContentDescription: String? = null,
 ) {
     Box(
         modifier = modifier
@@ -33,7 +34,7 @@ fun MiniFloatingIconButton(
         Icon(
             modifier = Modifier.size(24.dp),
             imageVector = imageVector,
-            contentDescription = null,
+            contentDescription = floatingButtonContentDescription,
             tint = Color.White,
         )
     }

--- a/app/src/main/kotlin/net/primal/android/editor/ui/NoteAttachmentPreview.kt
+++ b/app/src/main/kotlin/net/primal/android/editor/ui/NoteAttachmentPreview.kt
@@ -11,12 +11,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import java.util.UUID
 import net.primal.android.core.compose.PrimalLoadingSpinner
 import net.primal.android.editor.domain.NoteAttachment
 import net.primal.android.theme.AppTheme
+import net.primal.android.R
 
 @Composable
 fun NoteAttachmentPreview(
@@ -41,6 +43,7 @@ fun NoteAttachmentPreview(
             modifier = Modifier.align(Alignment.TopEnd),
             imageVector = Icons.Outlined.Close,
             onClick = { onDiscard(attachment.id) },
+            floatingButtonContentDescription = stringResource(id = R.string.accessibility_close),
         )
 
         if (attachment.remoteUrl == null) {
@@ -50,6 +53,7 @@ fun NoteAttachmentPreview(
                 MiniFloatingIconButton(
                     modifier = Modifier.align(Alignment.Center),
                     imageVector = Icons.Outlined.Refresh,
+                    floatingButtonContentDescription = stringResource(id = R.string.accessibility_refresh),
                     onClick = { onRetryUpload(attachment.id) },
                 )
             }

--- a/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
@@ -430,7 +430,7 @@ private fun NoteActionRow(maxItems: Int = 5, onPhotosImported: (List<Uri>) -> Un
         ) {
             Icon(
                 imageVector = PrimalIcons.ImportPhotoFromGallery,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.accessibility_import_photo_from_gallery),
                 tint = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
             )
         }

--- a/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
@@ -142,6 +142,7 @@ fun NoteEditorScreen(
                 title = "",
                 navigationIcon = Icons.Outlined.Close,
                 onNavigationIconClick = onClose,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_close),
                 showDivider = true,
                 actions = {
                     val text = when {

--- a/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
@@ -106,6 +106,11 @@ fun ExploreFeedScreen(
                         } else {
                             PrimalIcons.UserFeedAdd
                         },
+                        contentDescription = if (state.existsInUserFeeds) {
+                            stringResource(id = R.string.accessibility_remove_feed)
+                        } else {
+                            stringResource(id = R.string.accessibility_add_feed)
+                        },
                         onClick = {
                             if (state.existsInUserFeeds) {
                                 eventPublisher(RemoveFromUserFeeds)

--- a/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
@@ -106,7 +106,7 @@ fun ExploreFeedScreen(
                         } else {
                             PrimalIcons.UserFeedAdd
                         },
-                        contentDescription = if (state.existsInUserFeeds) {
+                        appBarIconContentDescription = if (state.existsInUserFeeds) {
                             stringResource(id = R.string.accessibility_remove_feed)
                         } else {
                             stringResource(id = R.string.accessibility_add_feed)

--- a/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/feed/ExploreFeedScreen.kt
@@ -98,6 +98,7 @@ fun ExploreFeedScreen(
                 title = state.title,
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 actions = {
                     AppBarIcon(
                         icon = if (state.existsInUserFeeds) {

--- a/app/src/main/kotlin/net/primal/android/explore/search/ui/SearchScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/search/ui/SearchScreen.kt
@@ -88,7 +88,8 @@ fun SearchScreen(
                     AppBarIcon(
                         icon = PrimalIcons.ArrowBack,
                         onClick = onClose,
-                    )
+                        contentDescription = stringResource(id = R.string.accessibility_back_button),
+                        )
                 },
                 title = {
                     SearchTextField(

--- a/app/src/main/kotlin/net/primal/android/explore/search/ui/SearchScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/explore/search/ui/SearchScreen.kt
@@ -88,7 +88,7 @@ fun SearchScreen(
                     AppBarIcon(
                         icon = PrimalIcons.ArrowBack,
                         onClick = onClose,
-                        contentDescription = stringResource(id = R.string.accessibility_back_button),
+                        appBarIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                         )
                 },
                 title = {

--- a/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
@@ -471,6 +471,8 @@ private fun MessageOutlinedTextField(
         AppBarIcon(
             modifier = Modifier.padding(bottom = 4.dp, start = 8.dp),
             icon = if (sending) Icons.Outlined.HourglassBottom else Icons.Outlined.ArrowUpward,
+            contentDescription = if (sending) stringResource(id = R.string.accessibility_message_being_sent) else stringResource(
+                id = R.string.accessibility_send_message),
             enabledBackgroundColor = AppTheme.colorScheme.primary,
             tint = Color.White,
             enabled = sendEnabled,

--- a/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
@@ -140,6 +140,7 @@ fun ChatScreen(
                 subtitle = state.participantProfile?.internetIdentifier?.formatNip05Identifier(),
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 actions = {
                     Box(
                         modifier = Modifier

--- a/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/messages/chat/ChatScreen.kt
@@ -471,7 +471,7 @@ private fun MessageOutlinedTextField(
         AppBarIcon(
             modifier = Modifier.padding(bottom = 4.dp, start = 8.dp),
             icon = if (sending) Icons.Outlined.HourglassBottom else Icons.Outlined.ArrowUpward,
-            contentDescription = if (sending) stringResource(id = R.string.accessibility_message_being_sent) else stringResource(
+            appBarIconContentDescription = if (sending) stringResource(id = R.string.accessibility_message_being_sent) else stringResource(
                 id = R.string.accessibility_send_message),
             enabledBackgroundColor = AppTheme.colorScheme.primary,
             tint = Color.White,

--- a/app/src/main/kotlin/net/primal/android/messages/conversation/MessageConversationListScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/messages/conversation/MessageConversationListScreen.kt
@@ -198,7 +198,7 @@ fun MessageListScreen(
                 content = {
                     Icon(
                         imageVector = PrimalIcons.NewDM,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.accessibility_new_direct_message),
                         tint = Color.White,
                     )
                 },

--- a/app/src/main/kotlin/net/primal/android/messages/conversation/create/NewConversationScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/messages/conversation/create/NewConversationScreen.kt
@@ -70,6 +70,7 @@ fun NewConversationScreen(
                 title = stringResource(id = R.string.new_message_title),
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 footer = {
                     SearchBar(
                         query = state.searchQuery,

--- a/app/src/main/kotlin/net/primal/android/notifications/list/NotificationsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/notifications/list/NotificationsScreen.kt
@@ -176,6 +176,7 @@ fun NotificationsScreen(
                     AppBarIcon(
                         icon = PrimalIcons.Settings,
                         onClick = onNotificationSettings,
+                        contentDescription = stringResource(id = R.string.accessibility_notification_settings),
                     )
                 },
             )

--- a/app/src/main/kotlin/net/primal/android/notifications/list/NotificationsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/notifications/list/NotificationsScreen.kt
@@ -176,7 +176,7 @@ fun NotificationsScreen(
                     AppBarIcon(
                         icon = PrimalIcons.Settings,
                         onClick = onNotificationSettings,
-                        contentDescription = stringResource(id = R.string.accessibility_notification_settings),
+                        appBarIconContentDescription = stringResource(id = R.string.accessibility_notification_settings),
                     )
                 },
             )

--- a/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
@@ -345,6 +345,7 @@ fun ProfileDetailsScreen(
                         navigationIcon = {
                             AppBarIcon(
                                 icon = PrimalIcons.ArrowBack,
+                                contentDescription = stringResource(id = R.string.accessibility_back_button),
                                 enabledBackgroundColor = Color.Black.copy(alpha = 0.5f),
                                 tint = Color.White,
                                 onClick = onClose,
@@ -917,11 +918,13 @@ private fun ProfileActions(
         ActionButton(
             onClick = onZapProfileClick,
             iconVector = PrimalIcons.FeedZaps,
+            contentDescription = stringResource(id = R.string.accessibility_profile_send_zap),
         )
 
         ActionButton(
             onClick = onMessageClick,
             iconVector = PrimalIcons.Message,
+            contentDescription = stringResource(id = R.string.accessibility_profile_messages),
         )
 
         if (!isActiveUser) {

--- a/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
@@ -554,6 +554,7 @@ private fun ProfileDropdownMenu(
     AppBarIcon(
         icon = PrimalIcons.More,
         onClick = { menuVisible = true },
+        contentDescription = stringResource(id = R.string.accessibility_profile_drop_down),
     )
 
     DropdownPrimalMenu(

--- a/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
@@ -345,7 +345,7 @@ fun ProfileDetailsScreen(
                         navigationIcon = {
                             AppBarIcon(
                                 icon = PrimalIcons.ArrowBack,
-                                contentDescription = stringResource(id = R.string.accessibility_back_button),
+                                appBarIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                                 enabledBackgroundColor = Color.Black.copy(alpha = 0.5f),
                                 tint = Color.White,
                                 onClick = onClose,
@@ -554,7 +554,7 @@ private fun ProfileDropdownMenu(
     AppBarIcon(
         icon = PrimalIcons.More,
         onClick = { menuVisible = true },
-        contentDescription = stringResource(id = R.string.accessibility_profile_drop_down),
+        appBarIconContentDescription = stringResource(id = R.string.accessibility_profile_drop_down),
     )
 
     DropdownPrimalMenu(

--- a/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/details/ProfileDetailsScreen.kt
@@ -1086,7 +1086,7 @@ private fun UserPublicKey(
             Image(
                 imageVector = Icons.Outlined.ContentCopy,
                 colorFilter = ColorFilter.tint(color = AppTheme.colorScheme.primary),
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.accessibility_copy_content),
             )
         }
     }

--- a/app/src/main/kotlin/net/primal/android/profile/edit/EditProfileScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/edit/EditProfileScreen.kt
@@ -75,6 +75,7 @@ fun EditProfileScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.profile_edit_profile_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = {
                     onClose()
                 },

--- a/app/src/main/kotlin/net/primal/android/profile/follows/ProfileFollowsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/profile/follows/ProfileFollowsScreen.kt
@@ -79,7 +79,8 @@ private fun ProfileFollowsScreen(
                 } ?: "",
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = onClose,
-            )
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
+                )
         },
         content = { paddingValues ->
             FollowsLazyColumn(

--- a/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
@@ -71,6 +71,7 @@ fun AppearanceSettingsScreen(
             PrimalTopAppBar(
                 title = "Appearance",
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
@@ -184,7 +184,7 @@ private fun ThemeBox(
             Image(
                 modifier = Modifier.align(alignment = Alignment.Center),
                 painter = painterResource(id = primalTheme.accent.logoId),
-                contentDescription = null,
+                contentDescription = primalTheme.name,
             )
 
             if (selected) {

--- a/app/src/main/kotlin/net/primal/android/settings/feeds/FeedsSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/feeds/FeedsSettingsScreen.kt
@@ -63,6 +63,7 @@ fun FeedsSettingsScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_feeds_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/home/SettingsHomeScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/home/SettingsHomeScreen.kt
@@ -55,6 +55,7 @@ fun SettingsHomeScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/keys/AccountSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/keys/AccountSettingsScreen.kt
@@ -69,6 +69,7 @@ fun AccountSettingsScreen(state: AccountSettingsContract.UiState, onClose: () ->
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_keys_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/muted/list/MutedSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/muted/list/MutedSettingsScreen.kt
@@ -64,6 +64,7 @@ fun MutedSettingsScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_muted_accounts_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
@@ -127,6 +127,7 @@ fun NetworkSettingsScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_network_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
@@ -296,7 +296,7 @@ private fun NewRelayOutlinedTextField(
             tint = Color.White,
             enabled = addRelayEnabled,
             onClick = onAddRelayConfirmed,
-            contentDescription = stringResource(id = R.string.accessibility_connect_relay),
+            appBarIconContentDescription = stringResource(id = R.string.accessibility_connect_relay),
         )
     }
 }

--- a/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/network/NetworkSettingsScreen.kt
@@ -296,6 +296,7 @@ private fun NewRelayOutlinedTextField(
             tint = Color.White,
             enabled = addRelayEnabled,
             onClick = onAddRelayConfirmed,
+            contentDescription = stringResource(id = R.string.accessibility_connect_relay),
         )
     }
 }

--- a/app/src/main/kotlin/net/primal/android/settings/notifications/NotificationsSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/notifications/NotificationsSettingsScreen.kt
@@ -74,6 +74,7 @@ fun NotificationsSettingsScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_notifications_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },

--- a/app/src/main/kotlin/net/primal/android/settings/wallet/WalletSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/wallet/WalletSettingsScreen.kt
@@ -96,6 +96,7 @@ fun WalletSettingsScreen(
             PrimalTopAppBar(
                 title = stringResource(id = R.string.settings_wallet_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
             )
         },
@@ -177,7 +178,12 @@ fun WalletSettingsScreen(
                                     supportText = "$maxBalanceInSats sats",
                                     trailingContent = {
                                         IconButton(onClick = { maxWalletBalanceShown = true }) {
-                                            Icon(imageVector = Icons.Outlined.Info, contentDescription = null)
+                                            Icon(
+                                                imageVector = Icons.Outlined.Info,
+                                                contentDescription = stringResource(
+                                                    id = R.string.accessibility_info,
+                                                ),
+                                            )
                                         }
                                     },
                                     onClick = { maxWalletBalanceShown = true },

--- a/app/src/main/kotlin/net/primal/android/settings/zaps/ZapSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/zaps/ZapSettingsScreen.kt
@@ -106,6 +106,7 @@ fun ZapSettingsScreen(
                 title = stringResource(id = R.string.settings_zaps_title),
                 navigationIcon = PrimalIcons.ArrowBack,
                 onNavigationIconClick = backSequence,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
             )
         },
         content = { paddingValues ->

--- a/app/src/main/kotlin/net/primal/android/thread/ThreadScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/thread/ThreadScreen.kt
@@ -212,6 +212,7 @@ fun ThreadScreen(
                 modifier = Modifier.onSizeChanged { topBarMaxHeightPx = it.height },
                 title = stringResource(id = R.string.thread_title),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 onNavigationIconClick = onClose,
                 showDivider = true,
             )

--- a/app/src/main/kotlin/net/primal/android/wallet/activation/WalletActivationScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/activation/WalletActivationScreen.kt
@@ -167,6 +167,7 @@ fun WalletActivationScreen(
                 },
                 showDivider = uiState.status != WalletActivationStatus.ActivationSuccess,
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 navigationIconTintColor = when (uiState.status) {
                     WalletActivationStatus.ActivationSuccess -> walletSuccessContentColor
                     else -> LocalContentColor.current

--- a/app/src/main/kotlin/net/primal/android/wallet/dashboard/ui/WalletActions.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/dashboard/ui/WalletActions.kt
@@ -1,5 +1,6 @@
 package net.primal.android.wallet.dashboard.ui
 
+import android.accounts.AuthenticatorDescription
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -69,7 +70,7 @@ private fun WalletActionButton(
             Icon(
                 modifier = Modifier.size(24.dp),
                 imageVector = icon,
-                contentDescription = null,
+                contentDescription = text,
             )
         }
 

--- a/app/src/main/kotlin/net/primal/android/wallet/transactions/details/TransactionDetailsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/transactions/details/TransactionDetailsScreen.kt
@@ -140,6 +140,7 @@ fun TransactionDetailsScreen(
             PrimalTopAppBar(
                 title = state.txData.resolveTitle(),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 showDivider = showTopBarDivider,
                 onNavigationIconClick = onClose,
             )

--- a/app/src/main/kotlin/net/primal/android/wallet/transactions/receive/ReceivePaymentScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/transactions/receive/ReceivePaymentScreen.kt
@@ -143,6 +143,7 @@ fun ReceivePaymentScreen(
                     ReceivePaymentTab.Bitcoin -> stringResource(id = R.string.wallet_receive_btc_transaction_title)
                 },
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 showDivider = false,
                 onNavigationIconClick = {
                     if (state.editMode) {

--- a/app/src/main/kotlin/net/primal/android/wallet/transactions/send/create/CreateTransactionScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/transactions/send/create/CreateTransactionScreen.kt
@@ -55,6 +55,7 @@ fun CreateTransactionScreen(
                         DraftTxStatus.Failed -> stringResource(id = R.string.wallet_create_transaction_failed_title)
                     },
                     navigationIcon = PrimalIcons.ArrowBack,
+                    navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                     showDivider = false,
                     onNavigationIconClick = onClose,
                 )

--- a/app/src/main/kotlin/net/primal/android/wallet/transactions/send/create/ui/TransactionSuccess.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/transactions/send/create/ui/TransactionSuccess.kt
@@ -69,6 +69,7 @@ fun TransactionSuccess(
             title = stringResource(id = R.string.wallet_create_transaction_success_title),
             textColor = walletSuccessContentColor,
             navigationIcon = PrimalIcons.ArrowBack,
+            navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
             showDivider = false,
             onNavigationIconClick = { closingSequence() },
             navigationIconTintColor = if (!isClosing) walletSuccessContentColor else AppTheme.colorScheme.onSurface,

--- a/app/src/main/kotlin/net/primal/android/wallet/transactions/send/prepare/SendPaymentScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/wallet/transactions/send/prepare/SendPaymentScreen.kt
@@ -112,6 +112,7 @@ fun SendPaymentScreen(
             PrimalTopAppBar(
                 title = stringResource(id = activeTab.data.labelResId),
                 navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
                 showDivider = activeTab != SendPaymentTab.Nostr,
                 onNavigationIconClick = {
                     closingScreen = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -518,4 +518,5 @@
     <string name="accessibility_repost_count">Repost count</string>
     <string name="accessibility_close">Close</string>
     <string name="accessibility_info">Info</string>
+    <string name="accessibility_import_photo_from_gallery">Import photo from gallery</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,6 +497,7 @@
     <string name="qrcode_scanner_cancel_button">Cancel</string>
 
     <string name="accessibility_back_button">Back</string>
+    <string name="accessibility_qr_code">QR Code</string>
     <string name="accessibility_profile_image">Profile image</string>
     <string name="accessibility_profile_messages">Messages</string>
     <string name="accessibility_profile_send_zap">Send zap</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,4 +520,6 @@
     <string name="accessibility_info">Info</string>
     <string name="accessibility_import_photo_from_gallery">Import photo from gallery</string>
     <string name="accessibility_refresh">Refresh</string>
+    <string name="accessibility_new_direct_message">New direct message</string>
+    <string name="accessibility_new_post">New post</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,4 +495,9 @@
     <string name="qrcode_scanner_permission_rationale">Primal needs access to your camera to scan QR codes.</string>
     <string name="qrcode_scanner_grant_permission_button">Allow access</string>
     <string name="qrcode_scanner_cancel_button">Cancel</string>
+
+    <string name="accessibility_back_button">Back</string>
+    <string name="accessibility_profile_image">Profile image</string>
+    <string name="accessibility_profile_messages">Messages</string>
+    <string name="accessibility_profile_send_zap">Send zap</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,4 +523,5 @@
     <string name="accessibility_new_direct_message">New direct message</string>
     <string name="accessibility_new_post">New post</string>
     <string name="accessibility_toggle_between_dark_and_light_mode">Toggle between dark and light mode</string>
+    <string name="accessibility_copy_content">Copy content</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -500,5 +500,16 @@
     <string name="accessibility_qr_code">QR Code</string>
     <string name="accessibility_profile_image">Profile image</string>
     <string name="accessibility_profile_messages">Messages</string>
+    <string name="accessibility_send_message">Send the message</string>
+    <string name="accessibility_message_being_sent">Message is being sent</string>
     <string name="accessibility_profile_send_zap">Send zap</string>
+    <string name="accessibility_note_drop_down">Note drop-down</string>
+    <string name="accessibility_profile_drop_down">Profile drop-down</string>
+    <string name="accessibility_media_drop_down">Media drop-down</string>
+    <string name="accessibility_feed_picker">Feed picker</string>
+    <string name="accessibility_add_feed">Add feed</string>
+    <string name="accessibility_remove_feed">Remove feed</string>
+    <string name="accessibility_notification_settings">Notification settings</string>
+    <string name="accessibility_delete_list_item">Delete list item</string>
+    <string name="accessibility_connect_relay">Connect relay</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -524,4 +524,5 @@
     <string name="accessibility_new_post">New post</string>
     <string name="accessibility_toggle_between_dark_and_light_mode">Toggle between dark and light mode</string>
     <string name="accessibility_copy_content">Copy content</string>
+    <string name="accessibility_warning">Warning</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,4 +516,6 @@
     <string name="accessibility_zaps_count">Zaps count</string>
     <string name="accessibility_likes_count">Likes count</string>
     <string name="accessibility_repost_count">Repost count</string>
+    <string name="accessibility_close">Close</string>
+    <string name="accessibility_info">Info</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,4 +522,5 @@
     <string name="accessibility_refresh">Refresh</string>
     <string name="accessibility_new_direct_message">New direct message</string>
     <string name="accessibility_new_post">New post</string>
+    <string name="accessibility_toggle_between_dark_and_light_mode">Toggle between dark and light mode</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,4 +512,8 @@
     <string name="accessibility_notification_settings">Notification settings</string>
     <string name="accessibility_delete_list_item">Delete list item</string>
     <string name="accessibility_connect_relay">Connect relay</string>
+    <string name="accessibility_replies_count">Replies count</string>
+    <string name="accessibility_zaps_count">Zaps count</string>
+    <string name="accessibility_likes_count">Likes count</string>
+    <string name="accessibility_repost_count">Repost count</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,4 +519,5 @@
     <string name="accessibility_close">Close</string>
     <string name="accessibility_info">Info</string>
     <string name="accessibility_import_photo_from_gallery">Import photo from gallery</string>
+    <string name="accessibility_refresh">Refresh</string>
 </resources>


### PR DESCRIPTION
Fix for https://github.com/PrimalHQ/primal-android-app/issues/76

The code could have been more compact but I have chosen clarity by creating new accessibility_* strings rather than using shortcuts.

### To test or develop accessibility:

Android studio:

- Select an emulator device that has Google Play Store available (eg Google Pixel 7 pro).
- Use an android image that has play store built in (eg Android 14).
- Use google play store on the emulator device to install Google Android Accessibility Suite.
- Turn on talkback in the settings. Make sure to enable the hovering shortcut so that you can toggle Talk Back on/off quickly.
