### PR TITLE
added font family to note edit text field

### DIFF
--- a/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/editor/ui/NoteEditorScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -282,6 +283,7 @@ fun NoteEditorScreen(
                                 },
                                 textStyle = AppTheme.typography.bodyMedium.copy(
                                     lineHeight = 20.sp,
+                                    fontFamily = FontFamily.SansSerif,
                                 ),
                                 colors = PrimalDefaults.outlinedTextFieldColors(
                                     focusedContainerColor = Color.Transparent,


### PR DESCRIPTION
This is odd... Currently AppTheme.typography.bodyMedium is used in OutlinedTextField and it has font family set as SansSerif... but I had to manually declare it.

Seems to have fixed the cut of accent issue.

Tested on Pixel 6 pro emulator (had the issue) and Pixel 7 Pro (didn't have the issue)

#98 