### PR TITLE
Handle `nostrUris` when parsing Uris

### DIFF
--- a/app/src/test/kotlin/net/primal/android/crypto/ConversionUtilsTest.kt
+++ b/app/src/test/kotlin/net/primal/android/crypto/ConversionUtilsTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.Test
 import org.spongycastle.util.encoders.DecoderException
 
+/* TODO: move this file to `core:utils` as well. `DecoderException` is left to be resolved. */
 class ConversionUtilsTest {
 
     @Test

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -71,6 +71,12 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.http)
+
+                implementation(libs.napier)
+
+                // Cryptography
+                implementation(libs.bitcoin.kmp)
+                implementation(libs.secp256k1.kmp)
             }
         }
 

--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/Constants.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/Constants.kt
@@ -1,0 +1,10 @@
+package net.primal.core.utils
+
+const val NOSTR = "nostr:"
+const val NPUB = "npub1"
+const val NSEC = "nsec1"
+const val NEVENT = "nevent1"
+const val NADDR = "naddr1"
+const val NOTE = "note1"
+const val NRELAY = "nrelay1"
+const val NPROFILE = "nprofile1"

--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/ConversionUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/ConversionUtils.kt
@@ -1,4 +1,4 @@
-package net.primal.domain.nostr.cryptography
+package net.primal.core.utils
 
 import fr.acinq.bitcoin.Bech32
 import fr.acinq.secp256k1.Hex

--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/NostrUriUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/NostrUriUtils.kt
@@ -49,7 +49,7 @@ fun String.isNostrUri(): Boolean {
         uri.startsWith(NEVENT) || uri.startsWith(NPROFILE)
 }
 
-fun String.cleanNostrUris(): String =
+fun String.clearAtSignFromNostrUris(): String =
     this
         .replace("@$NOSTR", NOSTR)
         .replace("@$NPUB", NPUB)

--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/NostrUriUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/NostrUriUtils.kt
@@ -1,0 +1,83 @@
+package net.primal.core.utils
+
+import io.github.aakira.napier.Napier
+
+
+private val nostrUriRegexPattern = Regex(
+    "($NOSTR)?@?($NSEC|$NPUB|$NEVENT|$NADDR|$NOTE|$NPROFILE|$NRELAY)([qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)([\\S]*)",
+    RegexOption.IGNORE_CASE,
+)
+
+fun String.parseNostrUris(): List<String> =
+    nostrUriRegexPattern.findAll(this)
+        .map { matchResult ->
+            matchResult.groupValues[1] + matchResult.groupValues[2] + matchResult.groupValues[3]
+        }
+        .filter { it.nostrUriToBytes() != null }
+        .toList()
+
+fun String.nostrUriToBytes(): ByteArray? {
+    val matchResult = nostrUriRegexPattern.find(this) ?: return null
+    val type = matchResult.groupValues[2].takeIf { it.isNotEmpty() }?.lowercase() ?: return null
+    val key = matchResult.groupValues[3].takeIf { it.isNotEmpty() }?.lowercase() ?: return null
+    return try {
+        (type + key).bechToBytesOrThrow()
+    } catch (ignored: Exception) {
+        Napier.w("", ignored)
+        null
+    }
+}
+
+fun String.extract(parser: (bechPrefix: String?, key: String?) -> String?): String? {
+    val matchResult = nostrUriRegexPattern.find(this) ?: return null
+
+    val bechPrefix = matchResult.groupValues.getOrNull(2)
+    val key = matchResult.groupValues.getOrNull(3)
+
+    return try {
+        parser(bechPrefix, key)
+    } catch (ignored: Exception) {
+        Napier.w("", ignored)
+        null
+    }
+}
+
+
+fun String.isNostrUri(): Boolean {
+    val uri = lowercase()
+    return uri.startsWith(NOSTR) || uri.startsWith(NPUB) || uri.startsWith(NOTE) ||
+        uri.startsWith(NEVENT) || uri.startsWith(NPROFILE)
+}
+
+fun String.cleanNostrUris(): String =
+    this
+        .replace("@$NOSTR", NOSTR)
+        .replace("@$NPUB", NPUB)
+        .replace("@$NOTE", NOTE)
+        .replace("@$NEVENT", NEVENT)
+        .replace("@$NADDR", NADDR)
+        .replace("@$NPROFILE", NPROFILE)
+
+fun String.isNote() = lowercase().startsWith(NOTE)
+
+fun String.isNPub() = lowercase().startsWith(NPUB)
+
+fun String.isNProfile() = lowercase().startsWith(NPROFILE)
+
+fun String.isNAddr() = lowercase().startsWith(NADDR)
+
+fun String.isNEvent() = lowercase().startsWith(NEVENT)
+
+fun String.isNoteUri() = lowercase().startsWith(NOSTR + NOTE)
+
+fun String.isNEventUri() = lowercase().startsWith(NOSTR + NEVENT)
+
+fun String.isNPubUri() = lowercase().startsWith(NOSTR + NPUB)
+
+fun String.isNProfileUri() = lowercase().startsWith(NOSTR + NPROFILE)
+
+fun String.isNAddrUri() = lowercase().startsWith(NOSTR + NADDR)
+
+fun String.nostrUriToNoteId() = nostrUriToBytes()?.toHex()
+
+fun String.nostrUriToPubkey() = nostrUriToBytes()?.toHex()

--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/UriUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/UriUtils.kt
@@ -13,8 +13,7 @@ fun String.parseUris(includeNostrUris: Boolean = true): List<String> {
     val detectedUrls = this.detectUrls()
 
     return if (includeNostrUris) {
-        // TODO: handle nostrUris
-        detectedUrls + emptyList()
+        this.parseNostrUris() + detectedUrls
     } else {
         detectedUrls
     }

--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/EventUriParsers.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/EventUriParsers.kt
@@ -2,6 +2,7 @@ package net.primal.data.repository.mappers.remote
 
 import net.primal.core.utils.asMapByKey
 import net.primal.core.utils.detectMimeType
+import net.primal.core.utils.isNostrUri
 import net.primal.data.local.dao.events.EventUri
 import net.primal.data.local.dao.messages.DirectMessageData
 import net.primal.data.local.dao.notes.PostData

--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/messages/processors/MessagesProcessor.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/messages/processors/MessagesProcessor.kt
@@ -2,6 +2,7 @@ package net.primal.data.repository.messages.processors
 
 import io.github.aakira.napier.Napier
 import net.primal.core.networking.sockets.errors.WssException
+import net.primal.core.utils.isNostrUri
 import net.primal.data.local.dao.messages.DirectMessageData
 import net.primal.data.local.db.PrimalDatabase
 import net.primal.data.local.db.withTransaction
@@ -13,7 +14,6 @@ import net.primal.data.repository.feed.processors.persistToDatabaseAsTransaction
 import net.primal.data.repository.mappers.remote.extractNoteId
 import net.primal.data.repository.mappers.remote.extractProfileId
 import net.primal.data.repository.mappers.remote.flatMapMessagesAsEventUriPO
-import net.primal.data.repository.mappers.remote.isNostrUri
 import net.primal.data.repository.mappers.remote.mapAsMessageDataPO
 import net.primal.data.repository.mappers.remote.mapAsPostDataPO
 import net.primal.data.repository.mappers.remote.mapAsProfileDataPO

--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/Nip19TLV.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/Nip19TLV.kt
@@ -7,8 +7,8 @@ import io.ktor.utils.io.core.toByteArray
 import io.ktor.utils.io.core.writeFully
 import kotlinx.io.readByteArray
 import kotlinx.io.readString
-import net.primal.domain.nostr.cryptography.bechToBytesOrThrow
-import net.primal.domain.nostr.cryptography.toHex
+import net.primal.core.utils.bechToBytesOrThrow
+import net.primal.core.utils.toHex
 
 object Nip19TLV {
     enum class Type(val id: Byte) {

--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/LightningExt.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/LightningExt.kt
@@ -1,6 +1,6 @@
 package net.primal.domain.nostr.utils
 
-import net.primal.domain.nostr.cryptography.bechToBytesOrThrow
+import net.primal.core.utils.bechToBytesOrThrow
 
 fun String.parseAsLNUrlOrNull(): String? {
     val parts = this.split("@")

--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/StringUtils.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/StringUtils.kt
@@ -2,7 +2,7 @@ package net.primal.domain.nostr.utils
 
 import fr.acinq.secp256k1.Hex
 import net.primal.core.utils.ellipsizeMiddle
-import net.primal.domain.nostr.cryptography.toNpub
+import net.primal.core.utils.toNpub
 
 fun String.asEllipsizedNpub(): String = Hex.decode(this).toNpub().ellipsizeMiddle(size = 8)
 

--- a/domain/nostr/src/commonTest/kotlin/net/primal/domain/nostr/Nip19TLVTest.kt
+++ b/domain/nostr/src/commonTest/kotlin/net/primal/domain/nostr/Nip19TLVTest.kt
@@ -8,8 +8,8 @@ import net.primal.domain.nostr.Nip19TLV.readAsString
 import net.primal.domain.nostr.Nip19TLV.toNaddrString
 import net.primal.domain.nostr.Nip19TLV.toNeventString
 import net.primal.domain.nostr.Nip19TLV.toNprofileString
-import net.primal.domain.nostr.cryptography.toHex
-import net.primal.domain.nostr.cryptography.toNpub
+import net.primal.core.utils.toHex
+import net.primal.core.utils.toNpub
 
 class Nip19TLVTest {
 

--- a/domain/primal/src/commonMain/kotlin/net/primal/domain/FeedExtensions.kt
+++ b/domain/primal/src/commonMain/kotlin/net/primal/domain/FeedExtensions.kt
@@ -1,6 +1,6 @@
 package net.primal.domain
 
-import net.primal.domain.nostr.cryptography.hexToNpubHrp
+import net.primal.core.utils.hexToNpubHrp
 
 fun String.isUserNotesFeedSpec(): Boolean {
     return this == "{\"id\":\"latest\",\"kind\":\"notes\"}"


### PR DESCRIPTION
Move ConversionUtils to `core:utils`;
Create Constants file;

Create NostrUriUtils in `core:utils` and move nostrUri logic there
    Not all logic could be moved. Some of it depends on Nip19. That was
    left in `NostrResources` and should be reconsidered.