### PR TITLE
Set `highlightNote` in `ThreadScreen` state on conversation change

### DIFF
--- a/app/src/main/kotlin/net/primal/android/thread/notes/ThreadViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/thread/notes/ThreadViewModel.kt
@@ -71,6 +71,8 @@ class ThreadViewModel @Inject constructor(
                 .filter { it.isNotEmpty() }
                 .map { posts -> posts.map { it.asFeedPostUi() } }
                 .collect { conversation ->
+                    setState { copy(highlightNote = conversation.find { it.postId == highlightPostId }) }
+
                     val highlightPostIndex = conversation.indexOfFirst { it.postId == highlightPostId }
                     if (_state.value.conversation.isEmpty() && highlightPostIndex != -1) {
                         setState {


### PR DESCRIPTION
`highlightNote` was never updated from `ViewModel` which have caused only null values in `ThreadScreen` which in turn caused all replies to not register as replies as `highlightNote` field was used as root element.