### PR TITLE
Implement topological sort for `FeedPost`

### DIFF
--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/feed/FeedRepositoryImpl.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/feed/FeedRepositoryImpl.kt
@@ -25,6 +25,7 @@ import net.primal.data.repository.feed.processors.persistNoteRepliesAndArticleCo
 import net.primal.data.repository.feed.processors.persistToDatabaseAsTransaction
 import net.primal.data.repository.mappers.local.mapAsFeedPostDO
 import net.primal.data.repository.mappers.remote.asFeedPageSnapshot
+import net.primal.data.repository.utils.performTopologicalSort
 import net.primal.domain.common.exception.NetworkException
 import net.primal.domain.feeds.supportsNoteReposts
 import net.primal.domain.posts.FeedPageSnapshot
@@ -152,6 +153,7 @@ internal class FeedRepositoryImpl(
             postId = noteId,
             userId = userId,
         ).map { list -> list.map { it.mapAsFeedPostDO() } }
+            .map { posts -> posts.performTopologicalSort() }
     }
 
     @OptIn(ExperimentalPagingApi::class)

--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/feed/FeedRepositoryImpl.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/feed/FeedRepositoryImpl.kt
@@ -25,7 +25,7 @@ import net.primal.data.repository.feed.processors.persistNoteRepliesAndArticleCo
 import net.primal.data.repository.feed.processors.persistToDatabaseAsTransaction
 import net.primal.data.repository.mappers.local.mapAsFeedPostDO
 import net.primal.data.repository.mappers.remote.asFeedPageSnapshot
-import net.primal.data.repository.utils.performTopologicalSort
+import net.primal.data.repository.utils.performTopologicalSortOrThis
 import net.primal.domain.common.exception.NetworkException
 import net.primal.domain.feeds.supportsNoteReposts
 import net.primal.domain.posts.FeedPageSnapshot
@@ -152,8 +152,9 @@ internal class FeedRepositoryImpl(
         return database.threadConversations().observeNoteConversation(
             postId = noteId,
             userId = userId,
-        ).map { list -> list.map { it.mapAsFeedPostDO() } }
-            .map { posts -> posts.performTopologicalSort() }
+        ).map { list ->
+            list.map { it.mapAsFeedPostDO() }.performTopologicalSortOrThis()
+        }
     }
 
     @OptIn(ExperimentalPagingApi::class)

--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/utils/ConversationUtils.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/utils/ConversationUtils.kt
@@ -6,10 +6,17 @@ import net.primal.domain.nostr.hasRootMarker
 import net.primal.domain.posts.FeedPost
 
 /**
+ * Tries to perform topological sort calling [performTopologicalSort].  In case the sort fails,
+ * returns the original list.
+ */
+fun List<FeedPost>.performTopologicalSortOrThis() = runCatching { performTopologicalSort() }.getOrDefault(this)
+
+/**
  * Performs a topological sort based on depth-first search as described
  * [here](https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search).
  *
  * Used to deal with some clients generating bad timestamps on thread chains.
+ * @throws IllegalStateException thrown in case a cycle is detected making sort impossible to complete.
  */
 fun List<FeedPost>.performTopologicalSort(): List<FeedPost> {
     val postsMap = this.associateBy { it.eventId }

--- a/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/utils/ConversationUtils.kt
+++ b/data/repository-caching/src/commonMain/kotlin/net/primal/data/repository/utils/ConversationUtils.kt
@@ -1,0 +1,50 @@
+package net.primal.data.repository.utils
+
+import net.primal.domain.nostr.getTagValueOrNull
+import net.primal.domain.nostr.hasReplyMarker
+import net.primal.domain.nostr.hasRootMarker
+import net.primal.domain.posts.FeedPost
+
+/**
+ * Performs a topological sort based on depth-first search as described
+ * [here](https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search).
+ *
+ * Used to deal with some clients generating bad timestamps on thread chains.
+ */
+fun List<FeedPost>.performTopologicalSort(): List<FeedPost> {
+    val postsMap = this.associateBy { it.eventId }
+    val adjacencyMap = mutableMapOf<String, MutableSet<String>>()
+
+    val permanentMark = mutableSetOf<String>()
+    val temporaryMark = mutableSetOf<String>()
+    val finalList = mutableListOf<FeedPost>()
+
+    this.forEach { post ->
+        post.tags.find { it.hasReplyMarker() }?.getTagValueOrNull()?.let {
+            adjacencyMap.getOrPut(key = it) { mutableSetOf() }
+                .add(post.eventId)
+        }
+        post.tags.find { it.hasRootMarker() }?.getTagValueOrNull()?.let {
+            adjacencyMap.getOrPut(key = it) { mutableSetOf() }
+                .add(post.eventId)
+        }
+    }
+
+    fun visit(node: FeedPost) {
+        if (permanentMark.contains(node.eventId)) return
+        if (temporaryMark.contains(node.eventId)) error("Impossible. Graph has cycle.")
+
+        temporaryMark.add(node.eventId)
+
+        adjacencyMap.getOrElse(key = node.eventId) { emptySet<String>() }
+            .forEach { id ->
+                postsMap[id]?.let { visit(it) }
+            }
+
+        permanentMark.add(node.eventId)
+        finalList.add(0, node)
+    }
+
+    this.forEach { visit(it) }
+    return finalList
+}


### PR DESCRIPTION
We have relied on `createdAt` timestamp to figure out the root post and correct chain of replies. We have seen some cases in which root post doesn't have oldest timestamp which renders this method obsolete. This implements topological sort that follows `reply` and `root` tags on posts to figure out the correct order. This has the same time complexity as the DFS and shouldn't cause performance issues.