### PR TITLE
Fix crash when navigating to mediaItem

### DIFF
--- a/app/src/main/kotlin/net/primal/android/navigation/PrimalAppNavigation.kt
+++ b/app/src/main/kotlin/net/primal/android/navigation/PrimalAppNavigation.kt
@@ -252,10 +252,10 @@ fun NavController.navigateToMediaGallery(
         "&$MEDIA_POSITION_MS=$mediaPositionMs",
 )
 
-fun NavController.navigateToMediaItem(mediaUrl: String) =
-    navigate(
-        route = "mediaItem/${mediaUrl.asUrlEncoded()}",
-    )
+fun NavController.navigateToMediaItem(mediaUrl: String) {
+    val encodedUrl = mediaUrl.asUrlEncoded()
+    navigate(route = "mediaItem?$MEDIA_URL=$encodedUrl")
+}
 
 fun NavController.navigateToExploreFeed(
     feedSpec: String,
@@ -775,10 +775,11 @@ fun SharedTransitionScope.PrimalAppNavigation(startDestination: String) {
         )
 
         mediaItem(
-            route = "mediaItem/{$MEDIA_URL}",
+            route = "mediaItem?$MEDIA_URL={$MEDIA_URL}",
             arguments = listOf(
                 navArgument(MEDIA_URL) {
                     type = NavType.StringType
+                    nullable = false
                 },
             ),
             navController = navController,


### PR DESCRIPTION
Crash occurred because encoded URLs used as path segments can contain characters (like '/') that break NavController's routing. Switched to using query parameters instead.