### PR TITLE
Fix crash on onboarding next step beyond last enum value

### DIFF
--- a/app/src/main/kotlin/net/primal/android/auth/onboarding/account/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/auth/onboarding/account/OnboardingViewModel.kt
@@ -221,9 +221,13 @@ class OnboardingViewModel @Inject constructor(
         }
     }
 
-    private fun OnboardingStep.nextStep() = OnboardingStep.fromIndex(this.index + 1)
+    private fun OnboardingStep.nextStep(): OnboardingStep {
+        return OnboardingStep.entries.find { it.index == this.index + 1 } ?: this
+    }
 
-    private fun OnboardingStep.previousStep() = OnboardingStep.fromIndex(this.index - 1)
+    private fun OnboardingStep.previousStep(): OnboardingStep {
+        return OnboardingStep.entries.find { it.index == this.index - 1 } ?: this
+    }
 
     private fun UiState.asProfileMetadata(): ProfileMetadata =
         ProfileMetadata(


### PR DESCRIPTION
Prevent IllegalArgumentException by safely handling out-of-bounds navigation in OnboardingStep.nextStep() and previousStep()