### PR TITLE
Filter Nostr URIs by text‐range overlap

### DIFF
--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/UriUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/UriUtils.kt
@@ -41,6 +41,33 @@ fun String.detectUrls(): List<String> {
     }.toList()
 }
 
+fun String.detectUrlsWithRanges(): List<Pair<String, IntRange>> {
+    return urlRegexPattern.findAll(this).map { mr ->
+        var url = mr.value
+        var start = mr.range.first
+        var end = mr.range.last + 1
+
+        val trimmed = url.trimEnd('.', ',', '!', '?')
+        if (trimmed.length != url.length) {
+            end -= (url.length - trimmed.length)
+            url = trimmed
+        }
+
+        when (this.getOrNull(start - 1)) {
+            '(' -> if (url.lastOrNull() == ')') {
+                url = url.dropLast(1)
+                end--
+            }
+            '[' -> if (url.lastOrNull() == ']') {
+                url = url.dropLast(1)
+                end--
+            }
+        }
+
+        url to (start until end)
+    }.toList()
+}
+
 fun String.ensureHttpOrHttps(): String =
     if (startsWith(prefix = "http://") || startsWith(prefix = "https://")) {
         this

--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/NostrUriUtils.kt
@@ -9,6 +9,7 @@ import net.primal.core.utils.NPROFILE
 import net.primal.core.utils.NPUB
 import net.primal.core.utils.NRELAY
 import net.primal.core.utils.NSEC
+import net.primal.core.utils.detectUrlsWithRanges
 import net.primal.domain.nostr.Nip19TLV
 import net.primal.domain.nostr.Nip19TLV.readAsString
 import net.primal.domain.nostr.cryptography.utils.bech32ToHexOrThrow
@@ -20,13 +21,23 @@ private val nostrUriRegexPattern = Regex(
     RegexOption.IGNORE_CASE,
 )
 
-fun String.parseNostrUris(): List<String> =
-    nostrUriRegexPattern.findAll(this)
-        .map { matchResult ->
-            matchResult.groupValues[1] + matchResult.groupValues[2] + matchResult.groupValues[3]
+fun String.parseNostrUris(): List<String> {
+    val urlMatches = this.detectUrlsWithRanges()
+
+    return nostrUriRegexPattern.findAll(this)
+        .map { mr ->
+            val uri = mr.groupValues[1] + mr.groupValues[2] + mr.groupValues[3]
+            uri to mr.range
         }
-        .filter { it.nostrUriToBytes() != null }
+        .filter { (uri, _) -> uri.nostrUriToBytes() != null }
+        .filter { (_, uriRange) ->
+            urlMatches.none { (_, urlRange) ->
+                uriRange.first >= urlRange.first && uriRange.last <= urlRange.last
+            }
+        }
+        .map { (uri, _) -> uri }
         .toList()
+}
 
 fun String.nostrUriToBytes(): ByteArray? {
     val matchResult = nostrUriRegexPattern.find(this) ?: return null


### PR DESCRIPTION
Only remove Nostr URIs whose **exact character range overlaps a detected URL**, preserving valid occurrences elsewhere.