### PR TITLE
Fix Bech32 crash - ArrayIndexOutOfBoundsException

### DIFF
--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/cryptography/utils/Bech32Util.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/cryptography/utils/Bech32Util.kt
@@ -64,14 +64,14 @@ object Bech32 {
         values.forEach { v ->
             val b = chk shr 25
             chk = ((chk and 0x1ffffff) shl 5) xor v.toInt()
-            for (i in 0..5) {
+            for (i in gen.indices) {
                 if (((b shr i) and 1) != 0) chk = chk xor gen[i]
             }
         }
         values1.forEach { v ->
             val b = chk shr 25
             chk = ((chk and 0x1ffffff) shl 5) xor v.toInt()
-            for (i in 0..5) {
+            for (i in gen.indices) {
                 if (((b shr i) and 1) != 0) chk = chk xor gen[i]
             }
         }


### PR DESCRIPTION
ArrayIndexOutOfBoundsException in Bech32.polymod due to the inner loop using for (i in 0..5) on a 5-element generator array (indices 0…4), which attempts to access gen[5].