### PR TITLE
Set `BigDecimal`s `DecimalMode` to US currency when dividing

### DIFF
--- a/core/utils/src/commonMain/kotlin/net/primal/core/utils/CurrencyConversionUtils.kt
+++ b/core/utils/src/commonMain/kotlin/net/primal/core/utils/CurrencyConversionUtils.kt
@@ -1,6 +1,7 @@
 package net.primal.core.utils
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 
 @Suppress("TooManyFunctions")
@@ -40,7 +41,7 @@ object CurrencyConversionUtils {
 
     fun BigDecimal.fromUsdToSats(exchangeBtcUsdRate: Double?): ULong {
         val rate = exchangeBtcUsdRate ?: 0.0
-        val btcAmount = divide(rate.toBigDecimal())
+        val btcAmount = divide(rate.toBigDecimal(decimalMode = DecimalMode.US_CURRENCY))
         return btcAmount.toSats()
     }
 


### PR DESCRIPTION
Default DecimalMode has unlimited `decimalPrecision` which causes a non-terminating result of division. `US_CURRENCY` mode uses biggest possible `decimalPrecision` which avoids this problem.