### PR TITLE
Rewrite `upsertFollowers` to avoid `ON CONFLICT` syntax

### DIFF
--- a/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/explore/FollowPackResponseProcessor.kt
+++ b/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/explore/FollowPackResponseProcessor.kt
@@ -58,7 +58,7 @@ internal suspend fun FollowListsResponse.processAndPersistFollowLists(database: 
         database.followPacks().upsertCrossRefs(refs = followPacks.buildFollowPackProfileCrossRefs())
         userFollowCount?.forEach { (profileId, followers) ->
             if (profileId.isNotEmpty()) {
-                database.profileStats().updateFollowersCount(
+                database.profileStats().upsertFollowers(
                     profileId = profileId,
                     followers = followers,
                 )


### PR DESCRIPTION
`ON CONFLICT` is not supported with the native SQLite build on devices below API 30.