### PR TITLE
Set initial state of `PrimalAsyncImage` to null

### DIFF
--- a/app/src/main/kotlin/net/primal/android/core/compose/PrimalAsyncImage.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/PrimalAsyncImage.kt
@@ -49,7 +49,7 @@ fun PrimalAsyncImage(
     clipToBounds: Boolean = true,
     onError: () -> Unit = {},
 ) {
-    var state by remember(model) { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+    var state by remember(model) { mutableStateOf<AsyncImagePainter.State?>(null) }
 
     AsyncImage(
         model = model,


### PR DESCRIPTION
Having `Empty` state as the initial caused already cached images to flash with loading placeholder for a bit before displaying image.