### PR TITLE
Increase `DELAY_ON_DISCONNECT` in `ConnectionIndicatorViewModel`

### DIFF
--- a/app/src/main/kotlin/net/primal/android/core/compose/connectionindicator/ConnectionIndicatorViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/connectionindicator/ConnectionIndicatorViewModel.kt
@@ -27,7 +27,7 @@ class ConnectionIndicatorViewModel @Inject constructor(
     }
 
     companion object {
-        private const val DELAY_ON_DISCONNECT = 2000L
+        private const val DELAY_ON_DISCONNECT = 10_000L
     }
 
     private fun observeCachingServiceConnection() =


### PR DESCRIPTION
Connection indicator proved to be too aggressive. By increasing this delay we are being more tolerant of common network devations.