### PR TITLE
Add `flowWithLifecycle` while observing connection status

### DIFF
--- a/app/src/main/kotlin/net/primal/android/core/compose/connectionindicator/ConnectionIndicatorViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/core/compose/connectionindicator/ConnectionIndicatorViewModel.kt
@@ -1,6 +1,8 @@
 package net.primal.android.core.compose.connectionindicator
 
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -32,12 +34,14 @@ class ConnectionIndicatorViewModel @Inject constructor(
 
     private fun observeCachingServiceConnection() =
         viewModelScope.launch {
-            primalApiClient.connectionStatus.collectLatest {
-                if (!it.connected) {
-                    delay(DELAY_ON_DISCONNECT)
-                }
+            primalApiClient.connectionStatus
+                .flowWithLifecycle(ProcessLifecycleOwner.get().lifecycle)
+                .collectLatest {
+                    if (!it.connected) {
+                        delay(DELAY_ON_DISCONNECT)
+                    }
 
-                setState { copy(hasConnection = it.connected) }
-            }
+                    setState { copy(hasConnection = it.connected) }
+                }
         }
 }


### PR DESCRIPTION
This prevents No Connection Indicator from showing after some time in background. Reason for this was that the flow was collected and delay processed in the background resulting in indicator immediately being shown upon resuming the app.