### PR TITLE
Remove optional arguments from home route

### DIFF
--- a/app/src/main/kotlin/net/primal/android/navigation/PrimalAppNavigation.kt
+++ b/app/src/main/kotlin/net/primal/android/navigation/PrimalAppNavigation.kt
@@ -565,8 +565,7 @@ private fun PrimalAppNavigation(
         )
 
         home(
-            route = "home?$PROFILE_NPUB={$PROFILE_NPUB}&$IDENTIFIER={$IDENTIFIER}" +
-                "&$PRIMAL_NAME={$PRIMAL_NAME}&$NADDR={$NADDR}",
+            route = "home",
             navController = navController,
             onTopLevelDestinationChanged = topLevelDestinationHandler,
             onDrawerScreenClick = drawerDestinationHandler,
@@ -574,18 +573,22 @@ private fun PrimalAppNavigation(
                 navArgument(PROFILE_NPUB) {
                     type = NavType.StringType
                     nullable = true
+                    defaultValue = null
                 },
                 navArgument(IDENTIFIER) {
                     type = NavType.StringType
                     nullable = true
+                    defaultValue = null
                 },
                 navArgument(PRIMAL_NAME) {
                     type = NavType.StringType
                     nullable = true
+                    defaultValue = null
                 },
                 navArgument(NADDR) {
                     type = NavType.StringType
                     nullable = true
+                    defaultValue = null
                 },
             ),
             deepLinks = listOf(


### PR DESCRIPTION
When handling deep links, the route gets updated with `null` arguments which causes the start destination to not be exactly the same which in turn causes the app to crash with "Sequence is empty".

Fixes: https://github.com/PrimalHQ/primal-android-app/issues/646