### PR TITLE
Invoke `finishAndRemoveTask()` when in `CREATED` lifecycle state on PiP change

### DIFF
--- a/app/src/main/kotlin/net/primal/android/MainActivity.kt
+++ b/app/src/main/kotlin/net/primal/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package net.primal.android
 
+import android.content.res.Configuration
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -17,6 +18,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -111,6 +113,14 @@ class MainActivity : FragmentActivity() {
                 }
             }
         }
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
+        if (lifecycle.currentState == Lifecycle.State.CREATED) {
+            finishAndRemoveTask()
+        }
+
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Makes sure to close Activity once the Picture-in-Picture is closed. This in turns closes our Service that plays stream in background.