### PR TITLE
Make `getAmountInSats` return `null` instead of throwing an error invalid invoice

### DIFF
--- a/core/networking-lightning/src/commonMain/kotlin/net/primal/core/lightning/LightningPayHelper.kt
+++ b/core/networking-lightning/src/commonMain/kotlin/net/primal/core/lightning/LightningPayHelper.kt
@@ -1,7 +1,6 @@
 package net.primal.core.lightning
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -85,11 +84,6 @@ class LightningPayHelper(
     private val thousandAsBigDecimal = BigDecimal.fromInt(1_000)
 
     private fun String.extractInvoiceAmountInMilliSats(): Long? {
-        return try {
-            LnInvoiceUtils.getAmountInSats(this).multiply(thousandAsBigDecimal).toLong()
-        } catch (error: LnInvoiceUtils.AddressFormatException) {
-            Napier.w(error) { "Cannot parse amount from LN invoice: \"$this\" — ${error.message}" }
-            null
-        }
+        return LnInvoiceUtils.getAmountInSatsOrNull(this)?.multiply(thousandAsBigDecimal)?.toLong()
     }
 }

--- a/data/caching/remote/src/commonMain/kotlin/net/primal/data/remote/factory/PublisherFactory.kt
+++ b/data/caching/remote/src/commonMain/kotlin/net/primal/data/remote/factory/PublisherFactory.kt
@@ -8,5 +8,4 @@ object PublisherFactory {
 
     fun createNostrEventImporter(primalApiClient: PrimalApiClient): NostrEventImporter =
         PrimalImportApiImpl(primalApiClient)
-
 }

--- a/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/NostrResources.kt
+++ b/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/NostrResources.kt
@@ -348,7 +348,7 @@ private fun takeAsReferencedZapOrNull(
         ?: zapRequest?.tags?.findFirstEventId()
 
     val amountInSats = (event?.tags?.findFirstBolt11() ?: zapRequest?.tags?.findFirstZapAmount())
-        ?.let(LnInvoiceUtils::getAmountInSats)
+        ?.let(LnInvoiceUtils::getAmountInSatsOrNull)
 
     if (receiverId == null || senderId == null || amountInSats == null) return null
 

--- a/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/ZapEvents.kt
+++ b/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/mappers/remote/ZapEvents.kt
@@ -32,7 +32,7 @@ fun List<NostrEvent>.mapAsEventZapDO(profilesMap: Map<String, ProfileData>) =
             ?: return@mapNotNull null
 
         val amountInSats = (zapReceipt.tags.findFirstBolt11() ?: zapRequest.tags.findFirstZapAmount())
-            ?.let(LnInvoiceUtils::getAmountInSats)
+            ?.let(LnInvoiceUtils::getAmountInSatsOrNull)
             ?: return@mapNotNull null
 
         val profile = profilesMap[senderId]

--- a/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/LnInvoiceUtils.kt
+++ b/domain/nostr/src/commonMain/kotlin/net/primal/domain/nostr/utils/LnInvoiceUtils.kt
@@ -253,8 +253,8 @@ object LnInvoiceUtils {
         return amount.multiply(multiplier(multiplierGroup))
     }
 
-    fun getAmountInSats(invoice: String): BigDecimal {
-        return getAmount(invoice).multiply(BigDecimal.fromInt(100_000_000))
+    fun getAmountInSatsOrNull(invoice: String): BigDecimal? {
+        return runCatching { getAmount(invoice).multiply(BigDecimal.fromInt(100_000_000)) }.getOrNull()
     }
 
     private fun multiplier(multiplier: String): BigDecimal {

--- a/domain/nostr/src/commonTest/kotlin/net/primal/domain/nostr/utils/LnInvoiceUtilsTest.kt
+++ b/domain/nostr/src/commonTest/kotlin/net/primal/domain/nostr/utils/LnInvoiceUtilsTest.kt
@@ -2,7 +2,7 @@ package net.primal.domain.nostr.utils
 
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import net.primal.core.utils.toInt
 
 class LnInvoiceUtilsTest {
@@ -36,35 +36,31 @@ class LnInvoiceUtilsTest {
             "lwpyt69v6zyjnheyqp8wlh7a3gn53qjzyzs6s44zjpd9sj8dp69uaspam64w2"
 
     @Test
-    fun getAmountInSatsValidInvoice() {
+    fun getAmountInSatsOrNullValidInvoice() {
         val expectedValue = 12345
 
-        val amount = LnInvoiceUtils.getAmountInSats(validLnInvoice)
+        val amount = LnInvoiceUtils.getAmountInSatsOrNull(validLnInvoice)
 
-        amount.toInt() shouldBe expectedValue
+        amount?.toInt() shouldBe expectedValue
     }
 
     @Test
-    fun getAmountInSatsValidInvoiceNoAmount() {
+    fun getAmountInSatsOrNullValidInvoiceNoAmount() {
         val expectedValue = 0
 
-        val amount = LnInvoiceUtils.getAmountInSats(validLnInvoiceNoAmount)
+        val amount = LnInvoiceUtils.getAmountInSatsOrNull(validLnInvoiceNoAmount)
 
-        amount.toInt() shouldBe expectedValue
+        amount?.toInt() shouldBe expectedValue
     }
 
     @Test
-    fun getAmountInSatsInvalidInvoice() {
-        assertFailsWith(IllegalArgumentException::class) {
-            LnInvoiceUtils.getAmountInSats(invalidLnInvoice)
-        }
+    fun getAmountInSatsOrNullInvalidInvoice() {
+        assertNull(LnInvoiceUtils.getAmountInSatsOrNull(invalidLnInvoice))
     }
 
     @Test
-    fun getAmountInSatsInvalidCharacter() {
-        assertFailsWith(IllegalArgumentException::class) {
-            LnInvoiceUtils.getAmountInSats(invoiceInvalidCharacter)
-        }
+    fun getAmountInSatsOrNullInvalidCharacter() {
+        assertNull(LnInvoiceUtils.getAmountInSatsOrNull(invoiceInvalidCharacter))
     }
 
     @Test


### PR DESCRIPTION
Closes: https://github.com/PrimalHQ/primal-android-app/issues/717