### PR TITLE
Fix Reads feed stuck loading on picker selection

### DIFF
--- a/app/src/main/kotlin/net/primal/android/articles/feed/ArticleFeedList.kt
+++ b/app/src/main/kotlin/net/primal/android/articles/feed/ArticleFeedList.kt
@@ -77,7 +77,13 @@ fun ArticleFeedList(
     header: @Composable (LazyItemScope.() -> Unit)? = null,
     stickyHeader: @Composable (LazyItemScope.() -> Unit)? = null,
 ) {
-    val viewModelKey by remember { mutableStateOf(if (!previewMode) feedSpec else UUID.randomUUID().toString()) }
+    val viewModelKey = remember(previewMode, feedSpec) {
+        if (!previewMode) {
+            "ArticleFeedViewModel_$feedSpec"
+        } else {
+            UUID.randomUUID().toString()
+        }
+    }
     val viewModel = hiltViewModel<ArticleFeedViewModel, ArticleFeedViewModel.Factory>(key = viewModelKey) { factory ->
         factory.create(spec = feedSpec)
     }

--- a/app/src/main/kotlin/net/primal/android/feeds/list/FeedListOverlayContent.kt
+++ b/app/src/main/kotlin/net/primal/android/feeds/list/FeedListOverlayContent.kt
@@ -35,7 +35,7 @@ fun FeedListOverlayContent(
     onEditAdvancedSearchFeedClick: ((feedSpec: String) -> Unit)? = null,
 ) {
     val viewModel = hiltViewModel<FeedListViewModel, FeedListViewModel.Factory>(
-        key = activeFeed.spec,
+        key = "FeedListViewModel_${activeFeed.spec}",
         creationCallback = { it.create(activeFeed = activeFeed, specKind = feedSpecKind) },
     )
     val uiState = viewModel.state.collectAsState()


### PR DESCRIPTION
ArticleFeedViewModel and FeedListViewModel both used the raw feedSpec as the ViewModel key while sharing MainScreen's ViewModelStore. When the feed picker opened (or dismissed and the active feed changed), the FeedListViewModel lookup collided with the existing ArticleFeedViewModel at the same key; ViewModelStore.put cleared the article VM mid-flight, cancelling its viewModelScope and orphaning the cachedIn-backed Pager.

Namespace both keys so they can no longer collide, mirroring what NoteFeedList already does.