### PR TITLE
Fix NIP-05 verification for domain-only identifiers

### DIFF
--- a/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/nip05/Nip05VerificationServiceImpl.kt
+++ b/data/caching/repository/src/commonMain/kotlin/net/primal/data/repository/nip05/Nip05VerificationServiceImpl.kt
@@ -217,14 +217,20 @@ class Nip05VerificationServiceImpl(
     )
 
     private suspend fun performVerification(pubkey: String, internetIdentifier: String): VerificationResult {
-        val parts = internetIdentifier.split("@")
-        if (parts.size != 2) {
-            Napier.d(tag = TAG) { "Invalid identifier format: $internetIdentifier" }
-            return VerificationResult(status = Nip05VerificationStatus.FAILED)
+        // Per NIP-05, when the local-part is omitted the client uses "_" as the local-part.
+        // Accept both "domain" and "@domain" as shorthand for "_@domain".
+        val (localPart, domain) = when {
+            !internetIdentifier.contains('@') -> "_" to internetIdentifier
+            else -> {
+                val parts = internetIdentifier.split("@")
+                if (parts.size != 2) {
+                    Napier.d(tag = TAG) { "Invalid identifier format: $internetIdentifier" }
+                    return VerificationResult(status = Nip05VerificationStatus.FAILED)
+                }
+                val rawLocal = parts[0]
+                (if (rawLocal.isEmpty()) "_" else rawLocal) to parts[1]
+            }
         }
-
-        val localPart = parts[0]
-        val domain = parts[1]
 
         if (!VALID_DOMAIN.matches(domain)) {
             Napier.d(tag = TAG) { "Invalid domain: $domain" }

--- a/data/caching/repository/src/desktopTest/kotlin/net/primal/data/repository/nip05/Nip05VerificationServiceTest.kt
+++ b/data/caching/repository/src/desktopTest/kotlin/net/primal/data/repository/nip05/Nip05VerificationServiceTest.kt
@@ -91,7 +91,46 @@ class Nip05VerificationServiceTest {
     fun `verifyIfNeeded sets FAILED for invalid identifier format`() =
         runTest {
             val (service, dao) = createService()
-            service.verifyIfNeeded(pubkey = testPubkey, internetIdentifier = "no-at-sign")
+            service.verifyIfNeeded(pubkey = testPubkey, internetIdentifier = "foo@bar@baz")
+
+            val slot = slot<Nip05VerificationData>()
+            coVerify { dao.upsert(capture(slot)) }
+            slot.captured.status shouldBe Nip05VerificationStatus.FAILED
+        }
+
+    @Test
+    fun `verifyIfNeeded verifies domain-only identifier against underscore entry`() =
+        runTest {
+            // NIP-05 shorthand: when local-part is omitted (e.g. "dergigi.com"),
+            // the client should look up the "_" entry in the well-known response.
+            val engine = createMockEngine(responseBody = """{"names":{"_":"$testPubkey"}}""")
+            val (service, dao) = createService(engine = engine)
+            service.verifyIfNeeded(pubkey = testPubkey, internetIdentifier = "dergigi.com")
+
+            val slot = slot<Nip05VerificationData>()
+            coVerify { dao.upsert(capture(slot)) }
+            slot.captured.status shouldBe Nip05VerificationStatus.VERIFIED
+            slot.captured.verifiedAddress shouldBe "dergigi.com"
+        }
+
+    @Test
+    fun `verifyIfNeeded verifies at-prefixed identifier against underscore entry`() =
+        runTest {
+            // "@dergigi.com" is treated equivalently to "_@dergigi.com".
+            val engine = createMockEngine(responseBody = """{"names":{"_":"$testPubkey"}}""")
+            val (service, dao) = createService(engine = engine)
+            service.verifyIfNeeded(pubkey = testPubkey, internetIdentifier = "@dergigi.com")
+
+            val slot = slot<Nip05VerificationData>()
+            coVerify { dao.upsert(capture(slot)) }
+            slot.captured.status shouldBe Nip05VerificationStatus.VERIFIED
+        }
+
+    @Test
+    fun `verifyIfNeeded sets FAILED for domain-only identifier with invalid domain`() =
+        runTest {
+            val (service, dao) = createService()
+            service.verifyIfNeeded(pubkey = testPubkey, internetIdentifier = "not a domain")
 
             val slot = slot<Nip05VerificationData>()
             coVerify { dao.upsert(capture(slot)) }


### PR DESCRIPTION
## Summary

NIP-05 verification was failing for users whose `nip05` metadata field is a bare domain (e.g. `dergigi.com`) instead of `_@dergigi.com`. The previous `performVerification` split on `@`, required exactly 2 parts, and returned `FAILED` otherwise — so any domain-only identifier never received a verification badge.

Per the [NIP-05 spec](https://github.com/nostr-protocol/nips/blob/master/05.md), when the local-part is omitted the client should look up the `_` entry in `/.well-known/nostr.json`. Reproduced live against `wss://nos.lol` / `wss://relay.dergigi.com`: dergigi's current kind-0 metadata literally contains `"nip05": "dergigi.com"`.

## Change

Routes domain-only (`dergigi.com`) and `@domain` (`@dergigi.com`) inputs to `localPart="_"` before the existing domain-validation + `_` lookup, while keeping truly malformed inputs (`foo@bar@baz`, empty) on the `FAILED` path.

- `data/caching/repository/.../nip05/Nip05VerificationServiceImpl.kt` — accept `domain` and `@domain` as `_@domain`
- `data/caching/repository/.../nip05/Nip05VerificationServiceTest.kt` — 3 new tests covering domain-only, `@domain`, and invalid-domain shorthand; updated the existing invalid-format test to a still-failing case (`foo@bar@baz`)

## Test plan

- [x] `./gradlew :data:caching:repository:desktopTest --tests "net.primal.data.repository.nip05.Nip05VerificationServiceTest"` — 25 tests / 0 failures, including the three new cases
- [x] `./gradlew :data:caching:repository:ktlintCheck` — BUILD SUCCESSFUL
- [x] `./gradlew :data:caching:repository:detekt` (JDK 21) — BUILD SUCCESSFUL
- [ ] Manual: open a profile whose `nip05` is a bare domain (e.g. `dergigi.com`) and confirm the verified badge appears

Not security-sensitive: NIP-05 is informational (badge only); no auth/crypto/signer/wallet touch points.