### PR TITLE
feat: add inline note translation

### DIFF
--- a/app/src/main/kotlin/net/primal/android/navigation/SettingsNavigation.kt
+++ b/app/src/main/kotlin/net/primal/android/navigation/SettingsNavigation.kt
@@ -53,6 +53,8 @@ import net.primal.android.settings.network.NetworkSettingsScreen
 import net.primal.android.settings.network.NetworkSettingsViewModel
 import net.primal.android.settings.notifications.NotificationsSettingsScreen
 import net.primal.android.settings.notifications.NotificationsSettingsViewModel
+import net.primal.android.settings.translation.TranslationSettingsScreen
+import net.primal.android.settings.translation.TranslationSettingsViewModel
 import net.primal.android.settings.wallet.domain.parseAsPrimalWalletNwc
 import net.primal.android.settings.wallet.nwc.primal.create.CreateNewWalletConnectionScreen
 import net.primal.android.settings.wallet.nwc.primal.create.CreateNewWalletConnectionViewModel
@@ -75,6 +77,7 @@ private fun NavController.navigateToWalletScanNwcUrl() = navigate(route = "walle
 private fun NavController.navigateToCreateNewWalletConnection() = navigate(route = "wallet_settings/create_new_nwc")
 private fun NavController.navigateToAppearanceSettings() = navigate(route = "appearance_settings")
 private fun NavController.navigateToContentDisplaySettings() = navigate(route = "content_display")
+private fun NavController.navigateToTranslationSettings() = navigate(route = "translation_settings")
 fun NavController.navigateToNotificationsSettings() = navigate(route = "notifications_settings")
 private fun NavController.navigateToZapsSettings() = navigate(route = "zaps_settings")
 private fun NavController.navigateToMutedAccounts() = navigate(route = "muted_accounts_settings")
@@ -131,6 +134,7 @@ fun NavGraphBuilder.settingsNavigation(route: String, navController: NavControll
                     PrimalSettingsSection.Network -> navController.navigateToNetworkSettings()
                     PrimalSettingsSection.Wallet -> navController.navigateToWalletSettings()
                     PrimalSettingsSection.Appearance -> navController.navigateToAppearanceSettings()
+                    PrimalSettingsSection.Translation -> navController.navigateToTranslationSettings()
                     PrimalSettingsSection.ContentDisplay -> navController.navigateToContentDisplaySettings()
                     PrimalSettingsSection.Notifications -> navController.navigateToNotificationsSettings()
                     PrimalSettingsSection.Zaps -> navController.navigateToZapsSettings()
@@ -172,6 +176,7 @@ fun NavGraphBuilder.settingsNavigation(route: String, navController: NavControll
         createNewWalletConnection(route = "wallet_settings/create_new_nwc", navController = navController)
         network(route = "network", navController = navController)
         appearance(route = "appearance_settings", navController = navController)
+        translation(route = "translation_settings", navController = navController)
         contentDisplay(route = "content_display", navController = navController)
         mutedAccounts(route = "muted_accounts_settings", navController = navController)
         mediaUploads(route = "media_uploads_settings", navController = navController)
@@ -445,6 +450,22 @@ private fun NavGraphBuilder.appearance(route: String, navController: NavControll
         val viewModel = appearanceSettingsViewModel(primalTheme = LocalPrimalTheme.current)
         LockToOrientationPortrait()
         AppearanceSettingsScreen(viewModel = viewModel, onClose = { navController.navigateUp() })
+    }
+
+private fun NavGraphBuilder.translation(route: String, navController: NavController) =
+    composable(
+        route = route,
+        enterTransition = { primalSlideInHorizontallyFromEnd },
+        exitTransition = { primalScaleOut },
+        popEnterTransition = { primalScaleIn },
+        popExitTransition = { primalSlideOutHorizontallyToEnd },
+    ) {
+        val viewModel = hiltViewModel<TranslationSettingsViewModel>(it)
+        LockToOrientationPortrait()
+        TranslationSettingsScreen(
+            viewModel = viewModel,
+            onClose = { navController.navigateUp() },
+        )
     }
 
 private fun NavGraphBuilder.contentDisplay(route: String, navController: NavController) =

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
@@ -1,0 +1,128 @@
+package net.primal.android.notes.feed.note.translation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.primal.android.R
+import net.primal.android.core.activity.LocalContentDisplaySettings
+import net.primal.android.theme.AppTheme
+
+@Composable
+fun NoteTranslationControls(
+    sourceText: String,
+    modifier: Modifier = Modifier,
+    contentColor: Color = AppTheme.colorScheme.onSurface,
+    actionColor: Color = AppTheme.colorScheme.secondary,
+) {
+    if (!sourceText.hasTranslatableText()) return
+
+    val context = LocalContext.current
+    val repository = remember(context) { NoteTranslationRepository(context.applicationContext) }
+    val settings = remember(sourceText) { repository.getSettings() }
+    if (!settings.enabled) return
+
+    val coroutineScope = rememberCoroutineScope()
+    var translationState by remember(sourceText, settings.endpoint, settings.targetLanguage) {
+        mutableStateOf<TranslationUiState>(TranslationUiState.Idle)
+    }
+
+    val displaySettings = LocalContentDisplaySettings.current
+
+    Column(modifier = modifier.padding(top = 2.dp, bottom = 4.dp)) {
+        Text(
+            modifier = Modifier.clickable(enabled = translationState !is TranslationUiState.Loading) {
+                when (val state = translationState) {
+                    TranslationUiState.Idle,
+                    is TranslationUiState.Error,
+                    -> {
+                        translationState = TranslationUiState.Loading
+                        coroutineScope.launch {
+                            val result = withContext(Dispatchers.IO) {
+                                repository.translate(sourceText)
+                            }
+                            translationState = result.fold(
+                                onSuccess = { TranslationUiState.Success(translation = it) },
+                                onFailure = { TranslationUiState.Error },
+                            )
+                        }
+                    }
+
+                    is TranslationUiState.Success -> {
+                        translationState = state.copy(showOriginal = !state.showOriginal)
+                    }
+
+                    TranslationUiState.Loading -> Unit
+                }
+            },
+            text = when (val state = translationState) {
+                TranslationUiState.Idle -> stringResource(id = R.string.feed_note_translate)
+                TranslationUiState.Loading -> stringResource(id = R.string.feed_note_translation_loading)
+                is TranslationUiState.Success -> if (state.showOriginal) {
+                    stringResource(id = R.string.feed_note_translation_show_translation)
+                } else {
+                    stringResource(id = R.string.feed_note_translation_show_original)
+                }
+
+                is TranslationUiState.Error -> stringResource(id = R.string.feed_note_translation_error)
+            },
+            style = AppTheme.typography.bodySmall,
+            color = actionColor,
+        )
+
+        val successState = translationState as? TranslationUiState.Success
+        if (successState != null) {
+            val translation = successState.translation
+            translation.detectedLanguage?.let { detectedLanguage ->
+                Text(
+                    modifier = Modifier.padding(top = 4.dp),
+                    text = stringResource(
+                        id = R.string.feed_note_translation_detected_language,
+                        detectedLanguage.uppercase(),
+                    ),
+                    style = AppTheme.typography.bodySmall,
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+                )
+            }
+            Text(
+                modifier = Modifier.padding(top = 4.dp),
+                text = if (successState.showOriginal) sourceText else translation.translatedText,
+                style = AppTheme.typography.bodyMedium.copy(
+                    color = contentColor,
+                    fontSize = displaySettings.contentAppearance.noteBodyFontSize,
+                    lineHeight = displaySettings.contentAppearance.noteBodyLineHeight,
+                ),
+            )
+        }
+    }
+}
+
+private sealed interface TranslationUiState {
+    data object Idle : TranslationUiState
+    data object Loading : TranslationUiState
+    data object Error : TranslationUiState
+    data class Success(
+        val translation: NoteTranslation,
+        val showOriginal: Boolean = false,
+    ) : TranslationUiState
+}
+
+private fun String.hasTranslatableText(): Boolean {
+    return length >= MIN_TRANSLATABLE_LENGTH && any { it.isLetter() }
+}
+
+private const val MIN_TRANSLATABLE_LENGTH = 12

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationRepository.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationRepository.kt
@@ -1,0 +1,212 @@
+package net.primal.android.notes.feed.note.translation
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+data class NoteTranslationSettings(
+    val enabled: Boolean = true,
+    val endpoint: String = NoteTranslationRepository.DEFAULT_ENDPOINT,
+    val apiKey: String = "",
+    val targetLanguage: String = NoteTranslationRepository.defaultTargetLanguage(),
+)
+
+data class NoteTranslation(
+    val translatedText: String,
+    val detectedLanguage: String?,
+    val fromCache: Boolean,
+)
+
+@Singleton
+class NoteTranslationRepository @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getSettings(): NoteTranslationSettings {
+        return NoteTranslationSettings(
+            enabled = prefs.getBoolean(KEY_ENABLED, true),
+            endpoint = prefs.getString(KEY_ENDPOINT, DEFAULT_ENDPOINT)?.ifBlank { DEFAULT_ENDPOINT } ?: DEFAULT_ENDPOINT,
+            apiKey = prefs.getString(KEY_API_KEY, "").orEmpty(),
+            targetLanguage = prefs.getString(KEY_TARGET_LANGUAGE, defaultTargetLanguage())
+                ?.ifBlank { defaultTargetLanguage() }
+                ?: defaultTargetLanguage(),
+        )
+    }
+
+    fun saveSettings(settings: NoteTranslationSettings) {
+        prefs.edit(commit = true) {
+            putBoolean(KEY_ENABLED, settings.enabled)
+            putString(KEY_ENDPOINT, settings.endpoint.trim().ifBlank { DEFAULT_ENDPOINT })
+            putString(KEY_API_KEY, settings.apiKey.trim())
+            putString(KEY_TARGET_LANGUAGE, settings.targetLanguage.trim().ifBlank { defaultTargetLanguage() })
+        }
+    }
+
+    fun restoreDefaults(): NoteTranslationSettings {
+        val defaults = NoteTranslationSettings()
+        saveSettings(defaults)
+        return defaults
+    }
+
+    fun translate(sourceText: String): Result<NoteTranslation> = runCatching {
+        val settings = getSettings()
+        require(settings.enabled) { "Translation is disabled." }
+
+        val targetLanguage = settings.targetLanguage.trim().lowercase(Locale.US)
+        require(targetLanguage.isNotBlank()) { "Target language is not configured." }
+
+        val protectedText = protectEntities(sourceText)
+        val cacheKey = buildCacheKey(
+            endpoint = settings.endpoint,
+            targetLanguage = targetLanguage,
+            sourceText = protectedText.text,
+        )
+
+        prefs.getString(cacheKey, null)?.let { cached ->
+            val json = JSONObject(cached)
+            return@runCatching NoteTranslation(
+                translatedText = json.getString(JSON_TRANSLATED_TEXT),
+                detectedLanguage = json.optString(JSON_DETECTED_LANGUAGE).takeIf { it.isNotBlank() },
+                fromCache = true,
+            )
+        }
+
+        val responseJson = requestTranslation(
+            settings = settings,
+            sourceText = protectedText.text,
+            targetLanguage = targetLanguage,
+        )
+        val translatedText = protectedText.restore(responseJson.getString("translatedText"))
+        val detectedLanguage = responseJson.detectedLanguage()
+
+        prefs.edit(commit = true) {
+            putString(
+                cacheKey,
+                JSONObject()
+                    .put(JSON_TRANSLATED_TEXT, translatedText)
+                    .put(JSON_DETECTED_LANGUAGE, detectedLanguage ?: "")
+                    .toString(),
+            )
+        }
+
+        NoteTranslation(
+            translatedText = translatedText,
+            detectedLanguage = detectedLanguage,
+            fromCache = false,
+        )
+    }
+
+    private fun requestTranslation(
+        settings: NoteTranslationSettings,
+        sourceText: String,
+        targetLanguage: String,
+    ): JSONObject {
+        val body = FormBody.Builder()
+            .add("q", sourceText)
+            .add("source", "auto")
+            .add("target", targetLanguage)
+            .apply {
+                settings.apiKey.trim().takeIf { it.isNotBlank() }?.let { apiKey ->
+                    add("api_key", apiKey)
+                }
+            }
+            .build()
+
+        val request = Request.Builder()
+            .url(settings.endpoint.trim())
+            .post(body)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val responseBody = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw IOException("Translation service returned HTTP ${response.code}.")
+            }
+            return JSONObject(responseBody)
+        }
+    }
+
+    private fun buildCacheKey(endpoint: String, targetLanguage: String, sourceText: String): String {
+        return "$CACHE_PREFIX${sha256("$endpoint\n$targetLanguage\n$sourceText")}"
+    }
+
+    private fun sha256(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray())
+        return digest.joinToString(separator = "") { "%02x".format(it) }
+    }
+
+    private fun JSONObject.detectedLanguage(): String? {
+        val detected = opt("detectedLanguage") ?: return null
+        return when (detected) {
+            is JSONObject -> detected.optString("language").takeIf { it.isNotBlank() }
+            is String -> detected.takeIf { it.isNotBlank() }
+            else -> null
+        }
+    }
+
+    private fun protectEntities(text: String): ProtectedText {
+        val replacements = linkedMapOf<String, String>()
+        var protected = text
+
+        PROTECTED_ENTITY_REGEX.findAll(text)
+            .map { it.value.trimEnd('.', ',', ';', ':', ')', ']') }
+            .distinct()
+            .forEachIndexed { index, entity ->
+                val placeholder = "__PRIMAL_TRANSLATION_ENTITY_${index}__"
+                replacements[placeholder] = entity
+                protected = protected.replace(entity, placeholder)
+            }
+
+        return ProtectedText(text = protected, replacements = replacements)
+    }
+
+    private data class ProtectedText(
+        val text: String,
+        val replacements: Map<String, String>,
+    ) {
+        fun restore(value: String): String {
+            var restored = value
+            replacements.forEach { (placeholder, entity) ->
+                restored = restored.replace(placeholder, entity)
+            }
+            return restored
+        }
+    }
+
+    companion object {
+        const val DEFAULT_ENDPOINT = "https://libretranslate.com/translate"
+
+        private const val PREFS_NAME = "note_translation"
+        private const val KEY_ENABLED = "enabled"
+        private const val KEY_ENDPOINT = "endpoint"
+        private const val KEY_API_KEY = "api_key"
+        private const val KEY_TARGET_LANGUAGE = "target_language"
+        private const val CACHE_PREFIX = "cache_"
+        private const val JSON_TRANSLATED_TEXT = "translatedText"
+        private const val JSON_DETECTED_LANGUAGE = "detectedLanguage"
+
+        private val client = OkHttpClient.Builder().build()
+
+        private val PROTECTED_ENTITY_REGEX = Regex(
+            pattern = """https?://\S+|nostr:\S+|\b(?:lnbc|bc1|npub1|note1|nevent1|nprofile1|naddr1)[a-zA-Z0-9]+\b|[#@][\p{L}\p{N}_.-]+""",
+        )
+
+        fun defaultTargetLanguage(): String {
+            return Locale.getDefault().language
+                .takeIf { it.isNotBlank() }
+                ?.lowercase(Locale.US)
+                ?: "en"
+        }
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
@@ -42,6 +42,7 @@ import net.primal.android.notes.feed.model.asNoteNostrUriUi
 import net.primal.android.notes.feed.note.ui.attachment.NoteAttachments
 import net.primal.android.notes.feed.note.ui.events.InvoicePayClickEvent
 import net.primal.android.notes.feed.note.ui.events.NoteCallbacks
+import net.primal.android.notes.feed.note.translation.NoteTranslationControls
 import net.primal.android.premium.legend.domain.asLegendaryCustomization
 import net.primal.android.stream.player.LocalStreamState
 import net.primal.android.theme.AppTheme
@@ -225,6 +226,15 @@ fun NoteContent(
                 overflow = overflow,
                 textSelectable = textSelectable,
                 onClick = clickHandler,
+            )
+
+            val translatableText = remember(contentText, seeMoreText) {
+                contentText.text.removeSuffix(" $seeMoreText")
+            }
+            NoteTranslationControls(
+                sourceText = translatableText,
+                contentColor = contentColor,
+                actionColor = highlightColor,
             )
         }
 

--- a/app/src/main/kotlin/net/primal/android/settings/home/PrimalSettingsSection.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/home/PrimalSettingsSection.kt
@@ -6,6 +6,7 @@ enum class PrimalSettingsSection {
     Network,
     Appearance,
     ConnectedApps,
+    Translation,
     ContentDisplay,
     MutedAccounts,
     MediaUploads,

--- a/app/src/main/kotlin/net/primal/android/settings/home/SettingsHomeScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/home/SettingsHomeScreen.kt
@@ -204,6 +204,7 @@ private fun PrimalSettingsSection.title(): String {
         PrimalSettingsSection.Network -> stringResource(id = R.string.settings_network_title)
         PrimalSettingsSection.Wallet -> stringResource(id = R.string.settings_wallet_title)
         PrimalSettingsSection.Appearance -> stringResource(id = R.string.settings_appearance_title)
+        PrimalSettingsSection.Translation -> stringResource(id = R.string.settings_translation_title)
         PrimalSettingsSection.ContentDisplay -> stringResource(id = R.string.settings_content_display_title)
         PrimalSettingsSection.Notifications -> stringResource(id = R.string.settings_notifications_title)
         PrimalSettingsSection.Zaps -> stringResource(id = R.string.settings_zaps_title)

--- a/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsContract.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsContract.kt
@@ -1,0 +1,21 @@
+package net.primal.android.settings.translation
+
+interface TranslationSettingsContract {
+    data class UiState(
+        val enabled: Boolean = true,
+        val endpoint: String = "",
+        val apiKey: String = "",
+        val targetLanguage: String = "",
+        val saved: Boolean = false,
+    )
+
+    sealed class UiEvent {
+        data class EnabledChanged(val enabled: Boolean) : UiEvent()
+        data class EndpointChanged(val endpoint: String) : UiEvent()
+        data class ApiKeyChanged(val apiKey: String) : UiEvent()
+        data class TargetLanguageChanged(val targetLanguage: String) : UiEvent()
+        data object Save : UiEvent()
+        data object RestoreDefaults : UiEvent()
+        data object SavedMessageShown : UiEvent()
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsScreen.kt
@@ -1,0 +1,210 @@
+package net.primal.android.settings.translation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import net.primal.android.R
+import net.primal.android.core.compose.PrimalDefaults
+import net.primal.android.core.compose.PrimalScaffold
+import net.primal.android.core.compose.PrimalSwitch
+import net.primal.android.core.compose.PrimalTopAppBar
+import net.primal.android.core.compose.icons.PrimalIcons
+import net.primal.android.core.compose.icons.primaliconpack.ArrowBack
+import net.primal.android.core.compose.settings.SettingsItem
+import net.primal.android.settings.translation.TranslationSettingsContract.UiEvent
+import net.primal.android.settings.translation.TranslationSettingsContract.UiState
+import net.primal.android.theme.AppTheme
+
+@Composable
+fun TranslationSettingsScreen(
+    viewModel: TranslationSettingsViewModel,
+    onClose: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    TranslationSettingsScreen(
+        state = state,
+        onClose = onClose,
+        eventPublisher = viewModel::setEvent,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TranslationSettingsScreen(
+    state: UiState,
+    onClose: () -> Unit,
+    eventPublisher: (UiEvent) -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val savedMessage = stringResource(id = R.string.settings_translation_saved)
+
+    LaunchedEffect(state.saved) {
+        if (state.saved) {
+            snackbarHostState.showSnackbar(savedMessage)
+            eventPublisher(UiEvent.SavedMessageShown)
+        }
+    }
+
+    PrimalScaffold(
+        topBar = {
+            PrimalTopAppBar(
+                title = stringResource(id = R.string.settings_translation_title),
+                navigationIcon = PrimalIcons.ArrowBack,
+                navigationIconContentDescription = stringResource(id = R.string.accessibility_back_button),
+                onNavigationIconClick = onClose,
+            )
+        },
+        content = { paddingValues ->
+            TranslationSettingsContent(
+                modifier = Modifier
+                    .background(color = AppTheme.colorScheme.surfaceVariant)
+                    .fillMaxWidth()
+                    .padding(paddingValues)
+                    .imePadding(),
+                state = state,
+                eventPublisher = eventPublisher,
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        },
+    )
+}
+
+@Composable
+private fun TranslationSettingsContent(
+    modifier: Modifier,
+    state: UiState,
+    eventPublisher: (UiEvent) -> Unit,
+) {
+    LazyColumn(modifier = modifier) {
+        item {
+            SettingsItem(
+                modifier = Modifier.padding(vertical = 8.dp),
+                headlineText = stringResource(id = R.string.settings_translation_enabled_title),
+                supportText = stringResource(id = R.string.settings_translation_enabled_description),
+                trailingContent = {
+                    PrimalSwitch(
+                        checked = state.enabled,
+                        onCheckedChange = { eventPublisher(UiEvent.EnabledChanged(it)) },
+                    )
+                },
+                onClick = { eventPublisher(UiEvent.EnabledChanged(!state.enabled)) },
+            )
+        }
+
+        item {
+            TranslationTextField(
+                value = state.endpoint,
+                onValueChange = { eventPublisher(UiEvent.EndpointChanged(it)) },
+                title = stringResource(id = R.string.settings_translation_endpoint_title),
+                placeholder = stringResource(id = R.string.settings_translation_endpoint_hint),
+                keyboardType = KeyboardType.Uri,
+            )
+        }
+
+        item {
+            TranslationTextField(
+                value = state.apiKey,
+                onValueChange = { eventPublisher(UiEvent.ApiKeyChanged(it)) },
+                title = stringResource(id = R.string.settings_translation_api_key_title),
+                placeholder = stringResource(id = R.string.settings_translation_api_key_hint),
+                keyboardType = KeyboardType.Text,
+            )
+        }
+
+        item {
+            TranslationTextField(
+                value = state.targetLanguage,
+                onValueChange = { eventPublisher(UiEvent.TargetLanguageChanged(it)) },
+                title = stringResource(id = R.string.settings_translation_target_language_title),
+                placeholder = stringResource(id = R.string.settings_translation_target_language_hint),
+                keyboardType = KeyboardType.Text,
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = { eventPublisher(UiEvent.RestoreDefaults) }) {
+                    Text(text = stringResource(id = R.string.settings_translation_restore_defaults))
+                }
+                TextButton(onClick = { eventPublisher(UiEvent.Save) }) {
+                    Text(text = stringResource(id = R.string.settings_translation_save))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TranslationTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    title: String,
+    placeholder: String,
+    keyboardType: KeyboardType,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Text(
+            modifier = Modifier.padding(bottom = 8.dp),
+            text = title.uppercase(),
+            style = AppTheme.typography.bodySmall,
+            color = AppTheme.extraColorScheme.onSurfaceVariantAlt1,
+        )
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            colors = PrimalDefaults.outlinedTextFieldColors(),
+            shape = AppTheme.shapes.medium,
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = AppTheme.typography.bodyMedium,
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt3,
+                    style = AppTheme.typography.bodyMedium,
+                )
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
+                keyboardType = keyboardType,
+                imeAction = ImeAction.Done,
+            ),
+        )
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/translation/TranslationSettingsViewModel.kt
@@ -1,0 +1,62 @@
+package net.primal.android.settings.translation
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import net.primal.android.notes.feed.note.translation.NoteTranslationRepository
+import net.primal.android.notes.feed.note.translation.NoteTranslationSettings
+import net.primal.android.settings.translation.TranslationSettingsContract.UiEvent
+import net.primal.android.settings.translation.TranslationSettingsContract.UiState
+
+@HiltViewModel
+class TranslationSettingsViewModel @Inject constructor(
+    private val repository: NoteTranslationRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(repository.getSettings().asUiState())
+    val state = _state.asStateFlow()
+
+    fun setEvent(event: UiEvent) {
+        when (event) {
+            is UiEvent.EnabledChanged -> setState { copy(enabled = event.enabled, saved = false) }
+            is UiEvent.EndpointChanged -> setState { copy(endpoint = event.endpoint, saved = false) }
+            is UiEvent.ApiKeyChanged -> setState { copy(apiKey = event.apiKey, saved = false) }
+            is UiEvent.TargetLanguageChanged -> setState { copy(targetLanguage = event.targetLanguage, saved = false) }
+            UiEvent.Save -> saveSettings()
+            UiEvent.RestoreDefaults -> restoreDefaults()
+            UiEvent.SavedMessageShown -> setState { copy(saved = false) }
+        }
+    }
+
+    private fun saveSettings() {
+        repository.saveSettings(state.value.asSettings())
+        setState { copy(saved = true) }
+    }
+
+    private fun restoreDefaults() {
+        val defaults = repository.restoreDefaults()
+        setState { defaults.asUiState(saved = true) }
+    }
+
+    private fun setState(reducer: UiState.() -> UiState) = _state.getAndUpdate(reducer)
+
+    private fun UiState.asSettings() =
+        NoteTranslationSettings(
+            enabled = enabled,
+            endpoint = endpoint,
+            apiKey = apiKey,
+            targetLanguage = targetLanguage,
+        )
+
+    private fun NoteTranslationSettings.asUiState(saved: Boolean = false) =
+        UiState(
+            enabled = enabled,
+            endpoint = endpoint,
+            apiKey = apiKey,
+            targetLanguage = targetLanguage,
+            saved = saved,
+        )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1062,6 +1062,19 @@
     <string name="settings_appearance_font_section_title">Font</string>
     <string name="settings_appearance_note_preview_section_title">Preview</string>
 
+    <string name="settings_translation_title">Translation</string>
+    <string name="settings_translation_enabled_title">Note translation</string>
+    <string name="settings_translation_enabled_description">Show inline translation controls below notes.</string>
+    <string name="settings_translation_endpoint_title">LibreTranslate endpoint</string>
+    <string name="settings_translation_endpoint_hint">https://libretranslate.com/translate</string>
+    <string name="settings_translation_api_key_title">API key</string>
+    <string name="settings_translation_api_key_hint">Optional</string>
+    <string name="settings_translation_target_language_title">Target language</string>
+    <string name="settings_translation_target_language_hint">en</string>
+    <string name="settings_translation_save">Save</string>
+    <string name="settings_translation_saved">Translation settings saved.</string>
+    <string name="settings_translation_restore_defaults">Restore defaults</string>
+
     <string name="settings_content_display_title">Content Display</string>
     <string name="settings_content_display_auto_play_videos">Auto play videos</string>
     <string name="settings_content_display_auto_play_videos_hint">Start playing videos automatically as you scroll the feed. Turn this off to use less network data.</string>
@@ -1739,6 +1752,12 @@
 
     <string name="feed_note_render_unknown_audio_title">Unknown title</string>
     <string name="feed_note_render_play_button">Play</string>
+    <string name="feed_note_translate">Translate</string>
+    <string name="feed_note_translation_loading">Translating...</string>
+    <string name="feed_note_translation_show_original">Show original</string>
+    <string name="feed_note_translation_show_translation">Show translation</string>
+    <string name="feed_note_translation_detected_language">Detected %1$s</string>
+    <string name="feed_note_translation_error">Translation unavailable. Tap to retry.</string>
 
     <string name="signer_connect_unknown_app">Unknown App</string>
     <string name="signer_connect_login_tab">Login</string>


### PR DESCRIPTION
## Summary

- add an inline Translate control below note content
- call a configurable LibreTranslate-compatible endpoint with optional API key and target language
- preserve Nostr refs, URLs, lightning/bitcoin IDs, hashtags, and mentions while translating
- cache translations locally by endpoint, target language, and note text hash
- add a Translation settings screen to enable/disable the feature and edit endpoint/API key/language

## Verification

- `git diff --check`
- attempted `./gradlew.bat :app:compileAospDebugKotlin`; Gradle starts, but this local machine has no Android SDK configured, so the task stops at `SDK location not found` before Kotlin compilation.
