### PR TITLE
Add native note translation with browser fallback

### DIFF
--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteDropdownMenu.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteDropdownMenu.kt
@@ -1,5 +1,8 @@
 package net.primal.android.notes.feed.note.ui
 
+import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,8 +21,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.launch
 import net.primal.android.R
 import net.primal.android.core.compose.dropdown.DropdownPrimalMenu
@@ -38,6 +44,7 @@ import net.primal.android.core.compose.icons.primaliconpack.ContextShare
 import net.primal.android.core.compose.icons.primaliconpack.ContextShareImage
 import net.primal.android.core.compose.icons.primaliconpack.Delete
 import net.primal.android.core.compose.icons.primaliconpack.More
+import net.primal.android.core.ext.openUriInExternalBrowser
 import net.primal.android.core.utils.copyText
 import net.primal.android.core.utils.resolvePrimalNoteLink
 import net.primal.android.core.utils.systemShareImage
@@ -73,6 +80,7 @@ fun NoteDropdownMenuIcon(
     var menuVisible by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
+    val targetLanguage = LocalLocale.current.platformLocale.language.ifBlank { "en" }
     val uiScope = rememberCoroutineScope()
     val copyConfirmationText = stringResource(id = R.string.feed_context_copied_toast)
 
@@ -149,6 +157,14 @@ fun NoteDropdownMenuIcon(
                             )
                         }
                     }
+                    menuVisible = false
+                },
+            )
+            DropdownPrimalMenuItem(
+                trailingIconVector = PrimalIcons.ContextCopyNoteText,
+                text = stringResource(id = R.string.feed_context_translate_note),
+                onClick = {
+                    context.translateNote(noteContent, targetLanguage)
                     menuVisible = false
                 },
             )
@@ -271,4 +287,30 @@ fun NoteDropdownMenuIcon(
             }
         }
     }
+}
+
+internal fun Context.translateNote(noteContent: String, targetLanguage: String) {
+    if (
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+        runCatching {
+            startActivity(
+                Intent(Intent.ACTION_TRANSLATE)
+                    .putExtra(Intent.EXTRA_TEXT, noteContent),
+            )
+        }.isSuccess
+    ) {
+        return
+    }
+
+    openUriInExternalBrowser(
+        uri = buildGoogleTranslateUrl(
+            noteContent = noteContent,
+            targetLanguage = targetLanguage,
+        ),
+    )
+}
+
+internal fun buildGoogleTranslateUrl(noteContent: String, targetLanguage: String): String {
+    val encodedText = URLEncoder.encode(noteContent, StandardCharsets.UTF_8.toString())
+    return "https://translate.google.com/?sl=auto&tl=$targetLanguage&text=$encodedText&op=translate"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,7 @@
     <string name="feed_context_share_note">Share Note</string>
     <string name="feed_context_share_poll">Share Poll</string>
     <string name="feed_context_share_note_as_image">Share as Image</string>
+    <string name="feed_context_translate_note">Translate Note</string>
     <string name="feed_context_copy_note_link">Copy Note Link</string>
     <string name="feed_context_copy_poll_link">Copy Poll Link</string>
     <string name="feed_context_add_to_bookmark">Add Bookmark</string>

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslationTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslationTest.kt
@@ -1,0 +1,65 @@
+package net.primal.android.notes.feed.note.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class NoteTranslationTest {
+
+    @Test
+    @Config(sdk = [31])
+    fun `translateNote uses Android translation service when available`() {
+        val context = RecordingContext()
+
+        context.translateNote(noteContent = "Hola 🌎", targetLanguage = "en")
+
+        context.startedIntents.single().apply {
+            action shouldBe Intent.ACTION_TRANSLATE
+            getCharSequenceExtra(Intent.EXTRA_TEXT) shouldBe "Hola 🌎"
+        }
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun `translateNote falls back to browser when translation service is unavailable`() {
+        val context = RecordingContext(failTranslationIntent = true)
+
+        context.translateNote(noteContent = "Hola & adiós", targetLanguage = "en")
+
+        context.startedIntents.last().apply {
+            action shouldBe Intent.ACTION_VIEW
+            data?.getQueryParameter("sl") shouldBe "auto"
+            data?.getQueryParameter("tl") shouldBe "en"
+            data?.getQueryParameter("text") shouldBe "Hola & adiós"
+        }
+    }
+
+    @Test
+    fun `buildGoogleTranslateUrl encodes note and target language`() {
+        buildGoogleTranslateUrl(
+            noteContent = "Hola, WNBA! #baloncesto",
+            targetLanguage = "en",
+        ) shouldBe "https://translate.google.com/?sl=auto&tl=en&text=Hola%2C+WNBA%21+%23baloncesto&op=translate"
+    }
+
+    private class RecordingContext(
+        private val failTranslationIntent: Boolean = false,
+    ) : ContextWrapper(ApplicationProvider.getApplicationContext<Context>()) {
+        val startedIntents = mutableListOf<Intent>()
+
+        override fun startActivity(intent: Intent) {
+            startedIntents += intent
+            if (failTranslationIntent && intent.action == Intent.ACTION_TRANSLATE) {
+                throw ActivityNotFoundException()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1055.

## Summary
- add a **Translate Note** action to the note menu
- use the native Android `ACTION_TRANSLATE` service when available
- fall back to Google Translate with the note and current app language encoded in the URL
- cover the native and fallback paths with Robolectric tests

This keeps translation provider-neutral on supported devices, requires no API key, and still works on older devices without a translation service.

## Verification
- `./gradlew :app:ktlintCheck`
- `./gradlew :app:detekt`