### PR TITLE
Add inline on-device note translation

### DIFF
--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
@@ -1,0 +1,147 @@
+package net.primal.android.notes.feed.note.translation
+
+import android.os.Build
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import net.primal.android.R
+import net.primal.android.theme.AppTheme
+
+internal sealed interface NoteTranslationUiState {
+    data object Idle : NoteTranslationUiState
+    data object Loading : NoteTranslationUiState
+    data class Success(val translation: TranslatedNote) : NoteTranslationUiState
+    data class Error(val reason: NoteTranslationException) : NoteTranslationUiState
+}
+
+@Composable
+internal fun NoteTranslationControls(
+    noteId: String,
+    text: String,
+) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || text.isBlank()) return
+
+    val context = LocalContext.current
+    val translator = remember(context) { SystemNoteTranslator(context.applicationContext) }
+    val scope = rememberCoroutineScope()
+    var state by remember(noteId, text) { mutableStateOf<NoteTranslationUiState>(NoteTranslationUiState.Idle) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        TranslationAction(
+            state = state,
+            onClick = {
+                when (state) {
+                    is NoteTranslationUiState.Success -> state = NoteTranslationUiState.Idle
+                    NoteTranslationUiState.Loading -> Unit
+                    else -> scope.launch {
+                        state = NoteTranslationUiState.Loading
+                        state = runCatching { translator.translate(text) }.fold(
+                            onSuccess = { NoteTranslationUiState.Success(it) },
+                            onFailure = {
+                                NoteTranslationUiState.Error(
+                                    it as? NoteTranslationException ?: NoteTranslationException.Failed,
+                                )
+                            },
+                        )
+                    }
+                }
+            },
+        )
+
+        when (val currentState = state) {
+            is NoteTranslationUiState.Success -> {
+                Text(
+                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+                    text = currentState.translation.text,
+                    style = AppTheme.typography.bodyMedium.copy(color = AppTheme.colorScheme.onSurface),
+                )
+                Text(
+                    text = stringResource(
+                        id = R.string.note_translation_target_language,
+                        currentState.translation.targetLanguage,
+                    ),
+                    style = AppTheme.typography.bodySmall.copy(
+                        color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+                    ),
+                )
+            }
+
+            is NoteTranslationUiState.Error -> Text(
+                modifier = Modifier.padding(top = 2.dp),
+                text = stringResource(id = currentState.reason.messageResource()),
+                style = AppTheme.typography.bodySmall.copy(color = AppTheme.colorScheme.error),
+            )
+
+            else -> Unit
+        }
+    }
+}
+
+@Composable
+private fun TranslationAction(
+    state: NoteTranslationUiState,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(top = 2.dp)
+            .clickable(enabled = state != NoteTranslationUiState.Loading, onClick = onClick)
+            .padding(vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (state == NoteTranslationUiState.Loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                color = AppTheme.colorScheme.secondary,
+                strokeWidth = 2.dp,
+            )
+        } else {
+            Icon(
+                modifier = Modifier.size(18.dp),
+                imageVector = Icons.Outlined.Translate,
+                contentDescription = null,
+                tint = AppTheme.colorScheme.secondary,
+            )
+        }
+        Text(
+            text = stringResource(
+                id = when (state) {
+                    NoteTranslationUiState.Loading -> R.string.note_translation_translating
+                    is NoteTranslationUiState.Success -> R.string.note_translation_hide
+                    is NoteTranslationUiState.Error -> R.string.note_translation_retry
+                    NoteTranslationUiState.Idle -> R.string.note_translation_action
+                },
+            ),
+            style = AppTheme.typography.bodySmall.copy(color = AppTheme.colorScheme.secondary),
+        )
+    }
+}
+
+internal fun NoteTranslationException.messageResource(): Int = when (this) {
+    NoteTranslationException.AlreadyInTargetLanguage -> R.string.note_translation_already_in_target
+    NoteTranslationException.LanguageNotDetected -> R.string.note_translation_language_not_detected
+    NoteTranslationException.Unavailable -> R.string.note_translation_unavailable
+    NoteTranslationException.Failed -> R.string.note_translation_failed
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
@@ -27,13 +27,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import net.primal.android.R
 import net.primal.android.theme.AppTheme
-
-internal sealed interface NoteTranslationUiState {
-    data object Idle : NoteTranslationUiState
-    data object Loading : NoteTranslationUiState
-    data class Success(val translation: TranslatedNote) : NoteTranslationUiState
-    data class Error(val reason: NoteTranslationException) : NoteTranslationUiState
-}
+import net.primal.core.utils.runCatching
 
 @Composable
 internal fun NoteTranslationControls(

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControls.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import net.primal.android.R
 import net.primal.android.theme.AppTheme
+import net.primal.core.utils.fold
 import net.primal.core.utils.runCatching
 
 @Composable

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationUiState.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationUiState.kt
@@ -1,0 +1,8 @@
+package net.primal.android.notes.feed.note.translation
+
+internal sealed interface NoteTranslationUiState {
+    data object Idle : NoteTranslationUiState
+    data object Loading : NoteTranslationUiState
+    data class Success(val translation: TranslatedNote) : NoteTranslationUiState
+    data class Error(val reason: NoteTranslationException) : NoteTranslationUiState
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal data class TranslatedNote(
     val text: String,
@@ -76,7 +78,7 @@ internal class SystemNoteTranslator(
     ): String = suspendCancellableCoroutine { continuation ->
         val manager = context.getSystemService(TranslationManager::class.java)
         if (manager == null) {
-            continuation.resumeWith(Result.failure(NoteTranslationException.Unavailable))
+            continuation.resumeWithException(NoteTranslationException.Unavailable)
             return@suspendCancellableCoroutine
         }
 
@@ -87,7 +89,7 @@ internal class SystemNoteTranslator(
 
         manager.createOnDeviceTranslator(translationContext, context.mainExecutor) { translator ->
             if (translator == null) {
-                continuation.resumeWith(Result.failure(NoteTranslationException.Unavailable))
+                continuation.resumeWithException(NoteTranslationException.Unavailable)
                 return@createOnDeviceTranslator
             }
             if (!continuation.isActive) {
@@ -127,9 +129,9 @@ internal class SystemNoteTranslator(
 
             translator.destroy()
             if (isSuccessful) {
-                continuation.resumeWith(Result.success(translatedText))
+                continuation.resume(translatedText)
             } else {
-                continuation.resumeWith(Result.failure(NoteTranslationException.Failed))
+                continuation.resumeWithException(NoteTranslationException.Failed)
             }
         }
     }

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
@@ -1,0 +1,140 @@
+package net.primal.android.notes.feed.note.translation
+
+import android.content.Context
+import android.icu.util.ULocale
+import android.os.Build
+import android.os.CancellationSignal
+import android.view.textclassifier.TextClassificationManager
+import android.view.textclassifier.TextLanguage
+import android.view.translation.TranslationContext
+import android.view.translation.TranslationManager
+import android.view.translation.TranslationRequest
+import android.view.translation.TranslationRequestValue
+import android.view.translation.TranslationResponse
+import android.view.translation.TranslationResponseValue
+import android.view.translation.TranslationSpec
+import android.view.translation.Translator
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+internal data class TranslatedNote(
+    val text: String,
+    val targetLanguage: String,
+)
+
+internal sealed class NoteTranslationException : Exception() {
+    data object Unavailable : NoteTranslationException()
+    data object LanguageNotDetected : NoteTranslationException()
+    data object AlreadyInTargetLanguage : NoteTranslationException()
+    data object Failed : NoteTranslationException()
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+internal class SystemNoteTranslator(
+    private val context: Context,
+) {
+    suspend fun translate(text: String): TranslatedNote {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            throw NoteTranslationException.Unavailable
+        }
+
+        val sourceLocale = detectLanguage(text)
+        val targetLocale = ULocale.forLocale(context.resources.configuration.locales[0])
+        if (sourceLocale.language == targetLocale.language) {
+            throw NoteTranslationException.AlreadyInTargetLanguage
+        }
+
+        val translatedText = translate(text = text, sourceLocale = sourceLocale, targetLocale = targetLocale)
+        return TranslatedNote(
+            text = translatedText,
+            targetLanguage = targetLocale.getDisplayLanguage(targetLocale),
+        )
+    }
+
+    private suspend fun detectLanguage(text: String): ULocale = withContext(Dispatchers.Default) {
+        val classifier = context.getSystemService(TextClassificationManager::class.java)?.textClassifier
+            ?: throw NoteTranslationException.Unavailable
+        val result = classifier.detectLanguage(TextLanguage.Request.Builder(text).build())
+        if (result.localeHypothesisCount == 0) {
+            throw NoteTranslationException.LanguageNotDetected
+        }
+
+        val locale = result.getLocale(0)
+        if (result.getConfidenceScore(locale) < MIN_LANGUAGE_CONFIDENCE) {
+            throw NoteTranslationException.LanguageNotDetected
+        }
+        locale
+    }
+
+    private suspend fun translate(
+        text: String,
+        sourceLocale: ULocale,
+        targetLocale: ULocale,
+    ): String = suspendCancellableCoroutine { continuation ->
+        val manager = context.getSystemService(TranslationManager::class.java)
+        if (manager == null) {
+            continuation.resumeWith(Result.failure(NoteTranslationException.Unavailable))
+            return@suspendCancellableCoroutine
+        }
+
+        val translationContext = TranslationContext.Builder(
+            TranslationSpec(sourceLocale, TranslationSpec.DATA_FORMAT_TEXT),
+            TranslationSpec(targetLocale, TranslationSpec.DATA_FORMAT_TEXT),
+        ).build()
+
+        manager.createOnDeviceTranslator(translationContext, context.mainExecutor) { translator ->
+            if (translator == null) {
+                continuation.resumeWith(Result.failure(NoteTranslationException.Unavailable))
+                return@createOnDeviceTranslator
+            }
+            if (!continuation.isActive) {
+                translator.destroy()
+                return@createOnDeviceTranslator
+            }
+
+            requestTranslation(
+                translator = translator,
+                text = text,
+                continuation = continuation,
+            )
+        }
+    }
+
+    private fun requestTranslation(
+        translator: Translator,
+        text: String,
+        continuation: CancellableContinuation<String>,
+    ) {
+        val cancellationSignal = CancellationSignal()
+        val request = TranslationRequest.Builder()
+            .setTranslationRequestValues(listOf(TranslationRequestValue.forText(text)))
+            .build()
+
+        continuation.invokeOnCancellation {
+            cancellationSignal.cancel()
+            translator.destroy()
+        }
+
+        translator.translate(request, cancellationSignal, context.mainExecutor) { response ->
+            val result = response.translationResponseValues[0]
+            val translatedText = result?.text?.toString()
+            val isSuccessful = response.translationStatus == TranslationResponse.TRANSLATION_STATUS_SUCCESS &&
+                result?.statusCode == TranslationResponseValue.STATUS_SUCCESS &&
+                !translatedText.isNullOrBlank()
+
+            translator.destroy()
+            if (isSuccessful) {
+                continuation.resumeWith(Result.success(translatedText))
+            } else {
+                continuation.resumeWith(Result.failure(NoteTranslationException.Failed))
+            }
+        }
+    }
+
+    private companion object {
+        const val MIN_LANGUAGE_CONFIDENCE = 0.5f
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
@@ -42,6 +42,7 @@ import net.primal.android.notes.feed.model.URL_ANNOTATION_TAG
 import net.primal.android.notes.feed.model.asNoteNostrUriUi
 import net.primal.android.notes.feed.model.computeRenderedNoteContent
 import net.primal.android.notes.feed.model.toAnnotatedString
+import net.primal.android.notes.feed.note.translation.NoteTranslationControls
 import net.primal.android.notes.feed.note.ui.attachment.NoteAttachments
 import net.primal.android.notes.feed.note.ui.events.InvoicePayClickEvent
 import net.primal.android.notes.feed.note.ui.events.NoteCallbacks
@@ -91,6 +92,14 @@ fun NoteContent(
                 highlightColor = highlightColor,
             )
     }
+    val translationText = remember(data, seeMoreText, highlightColor) {
+        renderContentAsAnnotatedString(
+            data = data,
+            expanded = true,
+            seeMoreText = seeMoreText,
+            highlightColor = highlightColor,
+        ).text
+    }
 
     Column(modifier = modifier) {
         if (contentText.isNotEmpty()) {
@@ -129,6 +138,11 @@ fun NoteContent(
                 overflow = overflow,
                 textSelectable = textSelectable,
                 onClick = clickHandler,
+            )
+
+            NoteTranslationControls(
+                noteId = data.noteId,
+                text = translationText,
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,6 +588,15 @@
     <string name="feed_context_mute_thread">Mute Thread</string>
     <string name="feed_context_request_delete">Request Delete</string>
     <string name="feed_context_copied_toast">Copied!</string>
+    <string name="note_translation_action">Translate</string>
+    <string name="note_translation_translating">Translating...</string>
+    <string name="note_translation_hide">Hide translation</string>
+    <string name="note_translation_retry">Retry translation</string>
+    <string name="note_translation_target_language">Translated to %1$s on this device</string>
+    <string name="note_translation_already_in_target">This note is already in your language.</string>
+    <string name="note_translation_language_not_detected">Couldn\'t detect the note\'s language.</string>
+    <string name="note_translation_unavailable">On-device translation isn\'t available for this language.</string>
+    <string name="note_translation_failed">Couldn\'t translate this note. Try again.</string>
 
     <string name="feed_lightning_invoice_title">Lightning Invoice</string>
     <string name="feed_lightning_invoice_pay_button">Pay</string>

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControlsTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationControlsTest.kt
@@ -1,0 +1,31 @@
+package net.primal.android.notes.feed.note.translation
+
+import io.kotest.matchers.shouldBe
+import net.primal.android.R
+import org.junit.Test
+
+class NoteTranslationControlsTest {
+
+    @Test
+    fun `already translated notes explain that translation is unnecessary`() {
+        NoteTranslationException.AlreadyInTargetLanguage.messageResource() shouldBe
+            R.string.note_translation_already_in_target
+    }
+
+    @Test
+    fun `language detection failures use a specific message`() {
+        NoteTranslationException.LanguageNotDetected.messageResource() shouldBe
+            R.string.note_translation_language_not_detected
+    }
+
+    @Test
+    fun `missing system service uses the unavailable message`() {
+        NoteTranslationException.Unavailable.messageResource() shouldBe
+            R.string.note_translation_unavailable
+    }
+
+    @Test
+    fun `translation errors remain retryable`() {
+        NoteTranslationException.Failed.messageResource() shouldBe R.string.note_translation_failed
+    }
+}


### PR DESCRIPTION
Closes #1055

## Summary
- add inline note translation through Android's on-device translation framework
- detect the source language locally and translate to the app/device language
- keep note text on the device with no API key, remote endpoint, or third-party dependency
- expose loading, success, already-translated, unavailable, and retry states
- translate the complete rendered note text instead of the collapsed feed preview

## Compatibility
- available on Android 12 (API 31) and newer when the device provides an on-device translation service
- hidden on older Android versions

## Verification
- `./gradlew ktlintCheck`
- `./gradlew detekt`
- `./gradlew :app:testAospDebugUnitTest` (340 tests)
- `./gradlew :app:compileAospDebugKotlin`
- verification run: https://github.com/ewbd09-svg/primal-android-app/actions/runs/29633532201