### PR TITLE
feat: hybrid on-device + LibreTranslate note translation (closes #1055)

### DIFF
--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/LibreTranslateClient.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/LibreTranslateClient.kt
@@ -28,7 +28,7 @@ class LibreTranslateClient(
             root.put("api_key", apiKey)
         }
 
-        val url = baseUrl.trimEnd('/') + "/translate"
+        val url = normalizeBaseUrl(baseUrl) + "/translate"
         val body = root.toString().toRequestBody(JSON_MEDIA)
         val request = Request.Builder().url(url).post(body).build()
         client.newCall(request).execute().use { response ->
@@ -37,7 +37,10 @@ class LibreTranslateClient(
                 throw IOException("LibreTranslate HTTP ${response.code}: $payload")
             }
             val json = JSONObject(payload)
-            return json.optString("translatedText").ifBlank {
+            val translated = json.optString("translatedText")
+                .ifBlank { json.optString("translation") }
+                .ifBlank { json.optString("text") }
+            return translated.ifBlank {
                 throw IOException("LibreTranslate missing translatedText")
             }
         }
@@ -56,6 +59,19 @@ class LibreTranslateClient(
         fun deviceLanguageCode(): String {
             val lang = Locale.getDefault().language
             return if (lang.isNullOrBlank()) "en" else lang
+        }
+
+        /**
+         * Accept base URL or full `/translate` path so settings never hit
+         * `.../translate/translate`.
+         */
+        fun normalizeBaseUrl(raw: String): String {
+            var cleaned = raw.trim().trimEnd('/')
+            if (cleaned.isEmpty()) return DEFAULT_BASE_URL
+            if (cleaned.endsWith("/translate", ignoreCase = true)) {
+                cleaned = cleaned.dropLast("/translate".length).trimEnd('/')
+            }
+            return cleaned.ifEmpty { DEFAULT_BASE_URL }
         }
     }
 }

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/LibreTranslateClient.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/LibreTranslateClient.kt
@@ -1,0 +1,61 @@
+package net.primal.android.notes.feed.note.translation
+
+import java.io.IOException
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/**
+ * Minimal LibreTranslate client (self-hosted or public instance).
+ * Default base URL can be overridden for privacy / reliability.
+ */
+class LibreTranslateClient(
+    private val baseUrl: String = DEFAULT_BASE_URL,
+    private val apiKey: String? = null,
+    private val client: OkHttpClient = defaultClient(),
+) {
+    fun translate(text: String, targetLang: String, sourceLang: String = "auto"): String {
+        val root = JSONObject()
+            .put("q", text)
+            .put("source", sourceLang)
+            .put("target", targetLang)
+            .put("format", "text")
+        if (!apiKey.isNullOrBlank()) {
+            root.put("api_key", apiKey)
+        }
+
+        val url = baseUrl.trimEnd('/') + "/translate"
+        val body = root.toString().toRequestBody(JSON_MEDIA)
+        val request = Request.Builder().url(url).post(body).build()
+        client.newCall(request).execute().use { response ->
+            val payload = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw IOException("LibreTranslate HTTP ${response.code}: $payload")
+            }
+            val json = JSONObject(payload)
+            return json.optString("translatedText").ifBlank {
+                throw IOException("LibreTranslate missing translatedText")
+            }
+        }
+    }
+
+    companion object {
+        const val DEFAULT_BASE_URL = "https://libretranslate.com"
+        private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
+
+        fun defaultClient(): OkHttpClient =
+            OkHttpClient.Builder()
+                .connectTimeout(20, TimeUnit.SECONDS)
+                .readTimeout(45, TimeUnit.SECONDS)
+                .build()
+
+        fun deviceLanguageCode(): String {
+            val lang = Locale.getDefault().language
+            return if (lang.isNullOrBlank()) "en" else lang
+        }
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
@@ -10,6 +10,7 @@ object NoteTextSanitizer {
         Regex("""\b(npub|nprofile|note|nevent|naddr|nrelay)1[a-z0-9]{6,}\b""", RegexOption.IGNORE_CASE),
         Regex("""https?://\S+"""),
         Regex("""lnbc[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""bc1[a-z0-9]+""", RegexOption.IGNORE_CASE),
         Regex("""#[\w_]+"""),
         Regex(""":[a-z0-9_+-]+:""", RegexOption.IGNORE_CASE),
     )

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
@@ -1,0 +1,42 @@
+package net.primal.android.notes.feed.note.translation
+
+/**
+ * Protects Nostr / URL tokens so translation providers do not mangle them.
+ * Mirrors the web client approach used for PrimalHQ/primal-web-app#133.
+ */
+object NoteTextSanitizer {
+    private val tokenPatterns: List<Regex> = listOf(
+        Regex("""nostr:[a-z0-9]+1[a-z0-9]{6,}""", RegexOption.IGNORE_CASE),
+        Regex("""\b(npub|nprofile|note|nevent|naddr|nrelay)1[a-z0-9]{6,}\b""", RegexOption.IGNORE_CASE),
+        Regex("""https?://\S+"""),
+        Regex("""lnbc[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""#[\w_]+"""),
+        Regex(""":[a-z0-9_+-]+:""", RegexOption.IGNORE_CASE),
+    )
+
+    data class Protected(val text: String, val tokens: List<String>)
+
+    fun protect(input: String): Protected {
+        var text = input
+        val tokens = mutableListOf<String>()
+        for (pattern in tokenPatterns) {
+            text = pattern.replace(text) { match ->
+                val idx = tokens.size
+                tokens += match.value
+                "⟦T$idx⟧"
+            }
+        }
+        return Protected(text = text, tokens = tokens)
+    }
+
+    fun restore(translated: String, tokens: List<String>): String {
+        var out = translated
+        tokens.forEachIndexed { idx, token ->
+            out = out.replace("⟦T$idx⟧", token)
+            // providers sometimes drop unicode brackets
+            out = out.replace("[T$idx]", token)
+            out = out.replace("[[T$idx]]", token)
+        }
+        return out
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
@@ -11,7 +11,8 @@ object NoteTextSanitizer {
         Regex("""https?://\S+"""),
         Regex("""lnbc[a-z0-9]+""", RegexOption.IGNORE_CASE),
         Regex("""bc1[a-z0-9]+""", RegexOption.IGNORE_CASE),
-        Regex("""#[\w_]+"""),
+        Regex("""(?<!\w)#[\w_]+"""),
+        Regex("""(?<!\w)@[\w.-]+"""),
         Regex(""":[a-z0-9_+-]+:""", RegexOption.IGNORE_CASE),
     )
 

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizer.kt
@@ -9,7 +9,13 @@ object NoteTextSanitizer {
         Regex("""nostr:[a-z0-9]+1[a-z0-9]{6,}""", RegexOption.IGNORE_CASE),
         Regex("""\b(npub|nprofile|note|nevent|naddr|nrelay)1[a-z0-9]{6,}\b""", RegexOption.IGNORE_CASE),
         Regex("""https?://\S+"""),
+        // bolt11 / bolt12 / lnurl / lightning: URIs / cashu tokens / on-chain bech32
+        Regex("""lightning:(?:lnbc|lno|lni|lnurl)[a-z0-9]+""", RegexOption.IGNORE_CASE),
         Regex("""lnbc[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""lno1[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""lni1[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""lnurl1[a-z0-9]+""", RegexOption.IGNORE_CASE),
+        Regex("""cashu[A-Za-z0-9][A-Za-z0-9+/=_-]+"""),
         Regex("""bc1[a-z0-9]+""", RegexOption.IGNORE_CASE),
         Regex("""(?<!\w)#[\w_]+"""),
         Regex("""(?<!\w)@[\w.-]+"""),

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -1,5 +1,6 @@
 package net.primal.android.notes.feed.note.translation
 
+import android.os.Build
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
@@ -22,8 +24,12 @@ import net.primal.android.theme.AppTheme
 private sealed interface TranslateUiState {
     data object Idle : TranslateUiState
     data object Loading : TranslateUiState
-    data class Ready(val text: String, val showingTranslation: Boolean) : TranslateUiState
-    data class Error(val message: String) : TranslateUiState
+    data class Ready(
+        val text: String,
+        val showingTranslation: Boolean,
+        val caption: String?,
+    ) : TranslateUiState
+    data class Error(val messageRes: Int) : TranslateUiState
 }
 
 @Composable
@@ -34,9 +40,12 @@ fun NoteTranslateControls(
 ) {
     if (noteText.isBlank()) return
 
+    val context = LocalContext.current
     var state by remember(noteText) { mutableStateOf<TranslateUiState>(TranslateUiState.Idle) }
     val scope = rememberCoroutineScope()
     val accent = AppTheme.colorScheme.secondary
+    val onDeviceCaption = stringResource(id = R.string.note_translation_via_on_device)
+    val networkCaption = stringResource(id = R.string.note_translation_via_network)
 
     Column(modifier = modifier.padding(top = 6.dp)) {
         when (val s = state) {
@@ -48,20 +57,13 @@ fun NoteTranslateControls(
                     modifier = Modifier.clickable {
                         state = TranslateUiState.Loading
                         scope.launch {
-                            state = runCatching {
-                                val protected = NoteTextSanitizer.protect(noteText)
-                                val target = LibreTranslateClient.deviceLanguageCode()
-                                val raw = withContext(Dispatchers.IO) {
-                                    LibreTranslateClient(baseUrl = libreTranslateBaseUrl)
-                                        .translate(protected.text, targetLang = target)
-                                }
-                                val restored = NoteTextSanitizer.restore(raw, protected.tokens)
-                                TranslateUiState.Ready(text = restored, showingTranslation = true)
-                            }.getOrElse {
-                                TranslateUiState.Error(
-                                    it.message ?: "translation failed",
-                                )
-                            }
+                            state = translateNote(
+                                noteText = noteText,
+                                context = context.applicationContext,
+                                libreTranslateBaseUrl = libreTranslateBaseUrl,
+                                onDeviceCaption = onDeviceCaption,
+                                networkCaption = networkCaption,
+                            )
                         }
                     },
                 )
@@ -79,8 +81,16 @@ fun NoteTranslateControls(
                         text = s.text,
                         style = AppTheme.typography.bodyMedium,
                         color = AppTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(bottom = 4.dp),
+                        modifier = Modifier.padding(bottom = 2.dp),
                     )
+                    s.caption?.let { caption ->
+                        Text(
+                            text = caption,
+                            style = AppTheme.typography.bodySmall,
+                            color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                    }
                     Text(
                         text = stringResource(id = R.string.note_translation_show_original),
                         color = accent,
@@ -102,7 +112,7 @@ fun NoteTranslateControls(
             }
             is TranslateUiState.Error -> {
                 Text(
-                    text = stringResource(id = R.string.note_translation_failed),
+                    text = stringResource(id = s.messageRes),
                     color = AppTheme.colorScheme.error,
                     style = AppTheme.typography.bodySmall,
                 )
@@ -116,5 +126,48 @@ fun NoteTranslateControls(
                 )
             }
         }
+    }
+}
+
+private suspend fun translateNote(
+    noteText: String,
+    context: android.content.Context,
+    libreTranslateBaseUrl: String,
+    onDeviceCaption: String,
+    networkCaption: String,
+): TranslateUiState {
+    // Prefer private on-device translation when available (API 31+).
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        try {
+            val result = SystemNoteTranslator(context).translate(noteText)
+            return TranslateUiState.Ready(
+                text = result.text,
+                showingTranslation = true,
+                caption = "$onDeviceCaption (${result.targetLanguage})",
+            )
+        } catch (_: NoteTranslationException.AlreadyInTargetLanguage) {
+            return TranslateUiState.Error(R.string.note_translation_already_in_target)
+        } catch (_: NoteTranslationException) {
+            // Fall through to LibreTranslate.
+        } catch (_: Throwable) {
+            // Fall through to LibreTranslate.
+        }
+    }
+
+    return runCatching {
+        val protected = NoteTextSanitizer.protect(noteText)
+        val target = LibreTranslateClient.deviceLanguageCode()
+        val raw = withContext(Dispatchers.IO) {
+            LibreTranslateClient(baseUrl = libreTranslateBaseUrl)
+                .translate(protected.text, targetLang = target)
+        }
+        val restored = NoteTextSanitizer.restore(raw, protected.tokens)
+        TranslateUiState.Ready(
+            text = restored,
+            showingTranslation = true,
+            caption = networkCaption,
+        )
+    }.getOrElse {
+        TranslateUiState.Error(R.string.note_translation_failed)
     }
 }

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -148,11 +148,14 @@ private suspend fun translateNote(
     networkCaption: String,
 ): TranslateUiState {
     // Prefer private on-device translation when available (API 31+).
+    // Protect identifiers first so TranslationManager cannot mangle them.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         try {
-            val result = SystemNoteTranslator(context).translate(noteText)
+            val protected = NoteTextSanitizer.protect(noteText)
+            val result = SystemNoteTranslator(context).translate(protected.text)
+            val restored = NoteTextSanitizer.restore(result.text, protected.tokens)
             return TranslateUiState.Ready(
-                text = result.text,
+                text = restored,
                 showingTranslation = true,
                 caption = "$onDeviceCaption (${result.targetLanguage})",
             )

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -1,0 +1,120 @@
+package net.primal.android.notes.feed.note.translation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.primal.android.R
+import net.primal.android.theme.AppTheme
+
+private sealed interface TranslateUiState {
+    data object Idle : TranslateUiState
+    data object Loading : TranslateUiState
+    data class Ready(val text: String, val showingTranslation: Boolean) : TranslateUiState
+    data class Error(val message: String) : TranslateUiState
+}
+
+@Composable
+fun NoteTranslateControls(
+    noteText: String,
+    modifier: Modifier = Modifier,
+    libreTranslateBaseUrl: String = LibreTranslateClient.DEFAULT_BASE_URL,
+) {
+    if (noteText.isBlank()) return
+
+    var state by remember(noteText) { mutableStateOf<TranslateUiState>(TranslateUiState.Idle) }
+    val scope = rememberCoroutineScope()
+    val accent = AppTheme.colorScheme.secondary
+
+    Column(modifier = modifier.padding(top = 6.dp)) {
+        when (val s = state) {
+            TranslateUiState.Idle -> {
+                Text(
+                    text = stringResource(id = R.string.note_translation_action),
+                    color = accent,
+                    style = AppTheme.typography.bodySmall,
+                    modifier = Modifier.clickable {
+                        state = TranslateUiState.Loading
+                        scope.launch {
+                            state = runCatching {
+                                val protected = NoteTextSanitizer.protect(noteText)
+                                val target = LibreTranslateClient.deviceLanguageCode()
+                                val raw = withContext(Dispatchers.IO) {
+                                    LibreTranslateClient(baseUrl = libreTranslateBaseUrl)
+                                        .translate(protected.text, targetLang = target)
+                                }
+                                val restored = NoteTextSanitizer.restore(raw, protected.tokens)
+                                TranslateUiState.Ready(text = restored, showingTranslation = true)
+                            }.getOrElse {
+                                TranslateUiState.Error(
+                                    it.message ?: "translation failed",
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+            TranslateUiState.Loading -> {
+                Text(
+                    text = stringResource(id = R.string.note_translation_translating),
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+                    style = AppTheme.typography.bodySmall,
+                )
+            }
+            is TranslateUiState.Ready -> {
+                if (s.showingTranslation) {
+                    Text(
+                        text = s.text,
+                        style = AppTheme.typography.bodyMedium,
+                        color = AppTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                    Text(
+                        text = stringResource(id = R.string.note_translation_show_original),
+                        color = accent,
+                        style = AppTheme.typography.bodySmall,
+                        modifier = Modifier.clickable {
+                            state = s.copy(showingTranslation = false)
+                        },
+                    )
+                } else {
+                    Text(
+                        text = stringResource(id = R.string.note_translation_show_translation),
+                        color = accent,
+                        style = AppTheme.typography.bodySmall,
+                        modifier = Modifier.clickable {
+                            state = s.copy(showingTranslation = true)
+                        },
+                    )
+                }
+            }
+            is TranslateUiState.Error -> {
+                Text(
+                    text = stringResource(id = R.string.note_translation_failed),
+                    color = AppTheme.colorScheme.error,
+                    style = AppTheme.typography.bodySmall,
+                )
+                Text(
+                    text = stringResource(id = R.string.note_translation_retry),
+                    color = accent,
+                    style = AppTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .padding(top = 2.dp)
+                        .clickable { state = TranslateUiState.Idle },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -36,16 +36,20 @@ private sealed interface TranslateUiState {
 fun NoteTranslateControls(
     noteText: String,
     modifier: Modifier = Modifier,
-    libreTranslateBaseUrl: String = LibreTranslateClient.DEFAULT_BASE_URL,
+    libreTranslateBaseUrl: String? = null,
 ) {
     if (noteText.isBlank()) return
 
     val context = LocalContext.current
+    val appContext = context.applicationContext
+    if (!NoteTranslationPreferences.isEnabled(appContext)) return
+
     var state by remember(noteText) { mutableStateOf<TranslateUiState>(TranslateUiState.Idle) }
     val scope = rememberCoroutineScope()
     val accent = AppTheme.colorScheme.secondary
     val onDeviceCaption = stringResource(id = R.string.note_translation_via_on_device)
     val networkCaption = stringResource(id = R.string.note_translation_via_network)
+    val resolvedBaseUrl = libreTranslateBaseUrl ?: NoteTranslationPreferences.baseUrl(appContext)
 
     Column(modifier = modifier.padding(top = 6.dp)) {
         when (val s = state) {
@@ -59,8 +63,8 @@ fun NoteTranslateControls(
                         scope.launch {
                             state = translateNote(
                                 noteText = noteText,
-                                context = context.applicationContext,
-                                libreTranslateBaseUrl = libreTranslateBaseUrl,
+                                context = appContext,
+                                libreTranslateBaseUrl = resolvedBaseUrl,
                                 onDeviceCaption = onDeviceCaption,
                                 networkCaption = networkCaption,
                             )
@@ -156,10 +160,13 @@ private suspend fun translateNote(
 
     return runCatching {
         val protected = NoteTextSanitizer.protect(noteText)
-        val target = LibreTranslateClient.deviceLanguageCode()
+        val target = NoteTranslationPreferences.targetLanguage(context)
+        val apiKey = NoteTranslationPreferences.apiKey(context)
         val raw = withContext(Dispatchers.IO) {
-            LibreTranslateClient(baseUrl = libreTranslateBaseUrl)
-                .translate(protected.text, targetLang = target)
+            LibreTranslateClient(
+                baseUrl = libreTranslateBaseUrl,
+                apiKey = apiKey,
+            ).translate(protected.text, targetLang = target)
         }
         val restored = NoteTextSanitizer.restore(raw, protected.tokens)
         TranslateUiState.Ready(

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -43,6 +43,7 @@ fun NoteTranslateControls(
     val context = LocalContext.current
     val appContext = context.applicationContext
     if (!NoteTranslationPreferences.isEnabled(appContext)) return
+    if (!shouldOfferTranslation(noteText)) return
 
     var state by remember(noteText) { mutableStateOf<TranslateUiState>(TranslateUiState.Idle) }
     val scope = rememberCoroutineScope()
@@ -133,6 +134,12 @@ fun NoteTranslateControls(
     }
 }
 
+internal fun shouldOfferTranslation(noteText: String): Boolean {
+    val trimmed = noteText.trim()
+    if (trimmed.length < MIN_TRANSLATE_LENGTH) return false
+    return trimmed.any { it.isLetter() }
+}
+
 private suspend fun translateNote(
     noteText: String,
     context: android.content.Context,
@@ -159,8 +166,17 @@ private suspend fun translateNote(
     }
 
     return runCatching {
-        val protected = NoteTextSanitizer.protect(noteText)
         val target = NoteTranslationPreferences.targetLanguage(context)
+        val cacheKey = "$libreTranslateBaseUrl|$target|$noteText"
+        TranslationSessionCache.get(cacheKey)?.let { cached ->
+            return@runCatching TranslateUiState.Ready(
+                text = cached,
+                showingTranslation = true,
+                caption = networkCaption,
+            )
+        }
+
+        val protected = NoteTextSanitizer.protect(noteText)
         val apiKey = NoteTranslationPreferences.apiKey(context)
         val raw = withContext(Dispatchers.IO) {
             LibreTranslateClient(
@@ -169,6 +185,7 @@ private suspend fun translateNote(
             ).translate(protected.text, targetLang = target)
         }
         val restored = NoteTextSanitizer.restore(raw, protected.tokens)
+        TranslationSessionCache.put(cacheKey, restored)
         TranslateUiState.Ready(
             text = restored,
             showingTranslation = true,
@@ -178,3 +195,27 @@ private suspend fun translateNote(
         TranslateUiState.Error(R.string.note_translation_failed)
     }
 }
+
+/** Session-scoped LRU cache for network translation results (per process). */
+internal object TranslationSessionCache {
+    private const val MAX_ENTRIES = 64
+    private val map = object : LinkedHashMap<String, String>(32, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>?): Boolean =
+            size > MAX_ENTRIES
+    }
+
+    @Synchronized
+    fun get(key: String): String? = map[key]
+
+    @Synchronized
+    fun put(key: String, value: String) {
+        map[key] = value
+    }
+
+    @Synchronized
+    fun clear() {
+        map.clear()
+    }
+}
+
+private const val MIN_TRANSLATE_LENGTH = 12

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslateControls.kt
@@ -29,6 +29,8 @@ private sealed interface TranslateUiState {
         val showingTranslation: Boolean,
         val caption: String?,
     ) : TranslateUiState
+    /** Non-failure status (e.g. already in target language). */
+    data class Info(val messageRes: Int) : TranslateUiState
     data class Error(val messageRes: Int) : TranslateUiState
 }
 
@@ -115,6 +117,13 @@ fun NoteTranslateControls(
                     )
                 }
             }
+            is TranslateUiState.Info -> {
+                Text(
+                    text = stringResource(id = s.messageRes),
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+                    style = AppTheme.typography.bodySmall,
+                )
+            }
             is TranslateUiState.Error -> {
                 Text(
                     text = stringResource(id = s.messageRes),
@@ -137,7 +146,12 @@ fun NoteTranslateControls(
 internal fun shouldOfferTranslation(noteText: String): Boolean {
     val trimmed = noteText.trim()
     if (trimmed.length < MIN_TRANSLATE_LENGTH) return false
-    return trimmed.any { it.isLetter() }
+    if (!trimmed.any { it.isLetter() }) return false
+    // Require real prose after stripping protected identifiers.
+    val prose = NoteTextSanitizer.protect(trimmed).text
+        .replace(Regex("""⟦T\d+⟧"""), " ")
+        .trim()
+    return prose.length >= 4 && prose.any { it.isLetter() }
 }
 
 private suspend fun translateNote(
@@ -160,7 +174,7 @@ private suspend fun translateNote(
                 caption = "$onDeviceCaption (${result.targetLanguage})",
             )
         } catch (_: NoteTranslationException.AlreadyInTargetLanguage) {
-            return TranslateUiState.Error(R.string.note_translation_already_in_target)
+            return TranslateUiState.Info(R.string.note_translation_already_in_target)
         } catch (_: NoteTranslationException) {
             // Fall through to LibreTranslate.
         } catch (_: Throwable) {
@@ -170,7 +184,8 @@ private suspend fun translateNote(
 
     return runCatching {
         val target = NoteTranslationPreferences.targetLanguage(context)
-        val cacheKey = "$libreTranslateBaseUrl|$target|$noteText"
+        val normalizedBase = LibreTranslateClient.normalizeBaseUrl(libreTranslateBaseUrl)
+        val cacheKey = "$normalizedBase|$target|$noteText"
         TranslationSessionCache.get(cacheKey)?.let { cached ->
             return@runCatching TranslateUiState.Ready(
                 text = cached,
@@ -180,10 +195,15 @@ private suspend fun translateNote(
         }
 
         val protected = NoteTextSanitizer.protect(noteText)
+        val prose = protected.text.replace(Regex("""⟦T\d+⟧"""), " ").trim()
+        if (prose.length < 4 || !prose.any { it.isLetter() }) {
+            return@runCatching TranslateUiState.Error(R.string.note_translation_failed)
+        }
+
         val apiKey = NoteTranslationPreferences.apiKey(context)
         val raw = withContext(Dispatchers.IO) {
             LibreTranslateClient(
-                baseUrl = libreTranslateBaseUrl,
+                baseUrl = normalizedBase,
                 apiKey = apiKey,
             ).translate(protected.text, targetLang = target)
         }

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationPreferences.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationPreferences.kt
@@ -23,16 +23,18 @@ object NoteTranslationPreferences {
 
     fun baseUrl(context: Context): String =
         prefs(context).getString(KEY_BASE_URL, null)
-            ?.trim()
+            ?.let { LibreTranslateClient.normalizeBaseUrl(it) }
             ?.takeIf { it.isNotEmpty() }
             ?: LibreTranslateClient.DEFAULT_BASE_URL
 
     fun setBaseUrl(context: Context, url: String) {
-        val cleaned = url.trim().trimEnd('/')
-        if (cleaned.isEmpty()) {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) {
             prefs(context).edit().remove(KEY_BASE_URL).apply()
         } else {
-            prefs(context).edit().putString(KEY_BASE_URL, cleaned).apply()
+            prefs(context).edit()
+                .putString(KEY_BASE_URL, LibreTranslateClient.normalizeBaseUrl(trimmed))
+                .apply()
         }
     }
 

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationPreferences.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/NoteTranslationPreferences.kt
@@ -1,0 +1,77 @@
+package net.primal.android.notes.feed.note.translation
+
+import android.content.Context
+import java.util.Locale
+
+/**
+ * Local preferences for LibreTranslate fallback (endpoint, API key, target language).
+ * Kept on-device via SharedPreferences so settings do not require account sync.
+ */
+object NoteTranslationPreferences {
+    private const val PREFS = "primal_note_translation"
+    private const val KEY_ENABLED = "enabled"
+    private const val KEY_BASE_URL = "base_url"
+    private const val KEY_API_KEY = "api_key"
+    private const val KEY_TARGET_LANG = "target_lang"
+
+    fun isEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_ENABLED, true)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    fun baseUrl(context: Context): String =
+        prefs(context).getString(KEY_BASE_URL, null)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: LibreTranslateClient.DEFAULT_BASE_URL
+
+    fun setBaseUrl(context: Context, url: String) {
+        val cleaned = url.trim().trimEnd('/')
+        if (cleaned.isEmpty()) {
+            prefs(context).edit().remove(KEY_BASE_URL).apply()
+        } else {
+            prefs(context).edit().putString(KEY_BASE_URL, cleaned).apply()
+        }
+    }
+
+    fun apiKey(context: Context): String? =
+        prefs(context).getString(KEY_API_KEY, null)?.takeIf { it.isNotBlank() }
+
+    fun setApiKey(context: Context, key: String) {
+        val cleaned = key.trim()
+        if (cleaned.isEmpty()) {
+            prefs(context).edit().remove(KEY_API_KEY).apply()
+        } else {
+            prefs(context).edit().putString(KEY_API_KEY, cleaned).apply()
+        }
+    }
+
+    fun targetLanguage(context: Context): String {
+        val stored = prefs(context).getString(KEY_TARGET_LANG, null)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        if (stored != null) {
+            return normalizeLang(stored)
+        }
+        return LibreTranslateClient.deviceLanguageCode()
+    }
+
+    fun setTargetLanguage(context: Context, language: String) {
+        val code = normalizeLang(language)
+        if (code.isEmpty()) {
+            prefs(context).edit().remove(KEY_TARGET_LANG).apply()
+        } else {
+            prefs(context).edit().putString(KEY_TARGET_LANG, code).apply()
+        }
+    }
+
+    fun normalizeLang(raw: String): String {
+        val first = raw.trim().lowercase(Locale.US).split('-', '_').firstOrNull().orEmpty()
+        return first.filter { it.isLetter() }.take(8)
+    }
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/translation/SystemNoteTranslator.kt
@@ -1,0 +1,148 @@
+package net.primal.android.notes.feed.note.translation
+
+import android.content.Context
+import android.icu.util.ULocale
+import android.os.Build
+import android.os.CancellationSignal
+import android.view.textclassifier.TextClassificationManager
+import android.view.textclassifier.TextLanguage
+import android.view.translation.TranslationContext
+import android.view.translation.TranslationManager
+import android.view.translation.TranslationRequest
+import android.view.translation.TranslationRequestValue
+import android.view.translation.TranslationResponse
+import android.view.translation.TranslationResponseValue
+import android.view.translation.TranslationSpec
+import android.view.translation.Translator
+import androidx.annotation.RequiresApi
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+
+internal data class TranslatedNote(
+    val text: String,
+    val targetLanguage: String,
+    val viaOnDevice: Boolean,
+)
+
+internal sealed class NoteTranslationException : Exception() {
+    data object Unavailable : NoteTranslationException()
+    data object LanguageNotDetected : NoteTranslationException()
+    data object AlreadyInTargetLanguage : NoteTranslationException()
+    data object Failed : NoteTranslationException()
+}
+
+/**
+ * On-device Android TranslationManager (API 31+).
+ * Used as the preferred path; LibreTranslate is the network fallback.
+ */
+@RequiresApi(Build.VERSION_CODES.S)
+internal class SystemNoteTranslator(
+    private val context: Context,
+) {
+    suspend fun translate(text: String): TranslatedNote {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            throw NoteTranslationException.Unavailable
+        }
+
+        val sourceLocale = detectLanguage(text)
+        val targetLocale = ULocale.forLocale(context.resources.configuration.locales[0])
+        if (sourceLocale.language == targetLocale.language) {
+            throw NoteTranslationException.AlreadyInTargetLanguage
+        }
+
+        val translatedText = translate(text = text, sourceLocale = sourceLocale, targetLocale = targetLocale)
+        return TranslatedNote(
+            text = translatedText,
+            targetLanguage = targetLocale.getDisplayLanguage(targetLocale),
+            viaOnDevice = true,
+        )
+    }
+
+    private suspend fun detectLanguage(text: String): ULocale = withContext(Dispatchers.Default) {
+        val classifier = context.getSystemService(TextClassificationManager::class.java)?.textClassifier
+            ?: throw NoteTranslationException.Unavailable
+        val result = classifier.detectLanguage(TextLanguage.Request.Builder(text).build())
+        if (result.localeHypothesisCount == 0) {
+            throw NoteTranslationException.LanguageNotDetected
+        }
+
+        val locale = result.getLocale(0)
+        if (result.getConfidenceScore(locale) < MIN_LANGUAGE_CONFIDENCE) {
+            throw NoteTranslationException.LanguageNotDetected
+        }
+        locale
+    }
+
+    private suspend fun translate(
+        text: String,
+        sourceLocale: ULocale,
+        targetLocale: ULocale,
+    ): String = suspendCancellableCoroutine { continuation ->
+        val manager = context.getSystemService(TranslationManager::class.java)
+        if (manager == null) {
+            continuation.resumeWithException(NoteTranslationException.Unavailable)
+            return@suspendCancellableCoroutine
+        }
+
+        val translationContext = TranslationContext.Builder(
+            TranslationSpec(sourceLocale, TranslationSpec.DATA_FORMAT_TEXT),
+            TranslationSpec(targetLocale, TranslationSpec.DATA_FORMAT_TEXT),
+        ).build()
+
+        manager.createOnDeviceTranslator(translationContext, context.mainExecutor) { translator ->
+            if (translator == null) {
+                continuation.resumeWithException(NoteTranslationException.Unavailable)
+                return@createOnDeviceTranslator
+            }
+            if (!continuation.isActive) {
+                translator.destroy()
+                return@createOnDeviceTranslator
+            }
+
+            requestTranslation(
+                translator = translator,
+                text = text,
+                continuation = continuation,
+            )
+        }
+    }
+
+    private fun requestTranslation(
+        translator: Translator,
+        text: String,
+        continuation: CancellableContinuation<String>,
+    ) {
+        val cancellationSignal = CancellationSignal()
+        val request = TranslationRequest.Builder()
+            .setTranslationRequestValues(listOf(TranslationRequestValue.forText(text)))
+            .build()
+
+        continuation.invokeOnCancellation {
+            cancellationSignal.cancel()
+            translator.destroy()
+        }
+
+        translator.translate(request, cancellationSignal, context.mainExecutor) { response ->
+            val result = response.translationResponseValues[0]
+            val translatedText = result?.text?.toString()
+            val isSuccessful = response.translationStatus == TranslationResponse.TRANSLATION_STATUS_SUCCESS &&
+                result?.statusCode == TranslationResponseValue.STATUS_SUCCESS &&
+                !translatedText.isNullOrBlank()
+
+            translator.destroy()
+            if (isSuccessful) {
+                continuation.resume(translatedText)
+            } else {
+                continuation.resumeWithException(NoteTranslationException.Failed)
+            }
+        }
+    }
+
+    private companion object {
+        const val MIN_LANGUAGE_CONFIDENCE = 0.5f
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
@@ -132,7 +132,7 @@ fun NoteContent(
                 onClick = clickHandler,
             )
 
-            // Inline note translation (Lightning Bounty #1055) via LibreTranslate + token sanitizer
+            // Inline note translation (#1055): on-device first, LibreTranslate fallback + token sanitizer
             NoteTranslateControls(noteText = data.content)
         }
 

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteContent.kt
@@ -42,6 +42,7 @@ import net.primal.android.notes.feed.model.URL_ANNOTATION_TAG
 import net.primal.android.notes.feed.model.asNoteNostrUriUi
 import net.primal.android.notes.feed.model.computeRenderedNoteContent
 import net.primal.android.notes.feed.model.toAnnotatedString
+import net.primal.android.notes.feed.note.translation.NoteTranslateControls
 import net.primal.android.notes.feed.note.ui.attachment.NoteAttachments
 import net.primal.android.notes.feed.note.ui.events.InvoicePayClickEvent
 import net.primal.android.notes.feed.note.ui.events.NoteCallbacks
@@ -130,6 +131,9 @@ fun NoteContent(
                 textSelectable = textSelectable,
                 onClick = clickHandler,
             )
+
+            // Inline note translation (Lightning Bounty #1055) via LibreTranslate + token sanitizer
+            NoteTranslateControls(noteText = data.content)
         }
 
         val referencedStreams = data.partitions.referencedStreams

--- a/app/src/main/kotlin/net/primal/android/settings/content/ContentDisplaySettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/content/ContentDisplaySettingsScreen.kt
@@ -5,16 +5,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import net.primal.android.R
 import net.primal.android.core.compose.PrimalScaffold
@@ -23,6 +32,8 @@ import net.primal.android.core.compose.PrimalTopAppBar
 import net.primal.android.core.compose.icons.PrimalIcons
 import net.primal.android.core.compose.icons.primaliconpack.ArrowBack
 import net.primal.android.core.compose.settings.SettingsItem
+import net.primal.android.notes.feed.note.translation.LibreTranslateClient
+import net.primal.android.notes.feed.note.translation.NoteTranslationPreferences
 import net.primal.android.settings.content.ContentDisplaySettingsContract.UiEvent
 import net.primal.android.theme.AppTheme
 import net.primal.android.user.domain.ContentDisplaySettings
@@ -135,7 +146,105 @@ private fun ContentDisplaySettingsScreen(
                         eventPublisher(UiEvent.UpdateShowFocusMode(enabled = !state.focusMode))
                     },
                 )
+
+                Spacer(modifier = Modifier.height(24.dp))
+                NoteTranslationSettingsSection()
             }
         },
     )
+}
+
+@Composable
+private fun NoteTranslationSettingsSection() {
+    val context = LocalContext.current.applicationContext
+    var enabled by remember { mutableStateOf(NoteTranslationPreferences.isEnabled(context)) }
+    var baseUrl by remember { mutableStateOf(NoteTranslationPreferences.baseUrl(context)) }
+    var apiKey by remember { mutableStateOf(NoteTranslationPreferences.apiKey(context).orEmpty()) }
+    var targetLang by remember { mutableStateOf(NoteTranslationPreferences.targetLanguage(context)) }
+
+    Text(
+        text = stringResource(id = R.string.settings_content_display_translation_section),
+        style = AppTheme.typography.titleMedium,
+        color = AppTheme.colorScheme.onSurface,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    SettingsItem(
+        headlineText = stringResource(id = R.string.settings_content_display_note_translation),
+        supportText = stringResource(id = R.string.settings_content_display_note_translation_hint),
+        trailingContent = {
+            PrimalSwitch(
+                checked = enabled,
+                onCheckedChange = {
+                    enabled = it
+                    NoteTranslationPreferences.setEnabled(context, it)
+                },
+            )
+        },
+        onClick = {
+            enabled = !enabled
+            NoteTranslationPreferences.setEnabled(context, enabled)
+        },
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+    ) {
+        OutlinedTextField(
+            value = baseUrl,
+            onValueChange = {
+                baseUrl = it
+                NoteTranslationPreferences.setBaseUrl(context, it.ifBlank { LibreTranslateClient.DEFAULT_BASE_URL })
+            },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            label = { Text(stringResource(id = R.string.settings_content_display_translation_endpoint)) },
+            supportingText = {
+                Text(stringResource(id = R.string.settings_content_display_translation_endpoint_hint))
+            },
+            enabled = enabled,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = apiKey,
+            onValueChange = {
+                apiKey = it
+                NoteTranslationPreferences.setApiKey(context, it)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            label = { Text(stringResource(id = R.string.settings_content_display_translation_api_key)) },
+            enabled = enabled,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = targetLang,
+            onValueChange = {
+                targetLang = it
+                NoteTranslationPreferences.setTargetLanguage(context, it)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            label = { Text(stringResource(id = R.string.settings_content_display_translation_language)) },
+            supportingText = {
+                Text(stringResource(id = R.string.settings_content_display_translation_language_hint))
+            },
+            enabled = enabled,
+        )
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1878,4 +1878,7 @@
     <string name="note_translation_show_translation">Show translation</string>
     <string name="note_translation_failed">Couldn\'t translate this note.</string>
     <string name="note_translation_retry">Retry</string>
+    <string name="note_translation_already_in_target">This note is already in your language.</string>
+    <string name="note_translation_via_on_device">Translated on this device</string>
+    <string name="note_translation_via_network">Translated via network (LibreTranslate)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1870,4 +1870,12 @@
     <string name="poll_votes_no_voters">Voters will show up here.</string>
     <string name="poll_votes_sats_suffix">sats</string>
     <string name="poll_votes_see_votes">see votes</string>
+
+    <!-- Note translation (issue #1055) -->
+    <string name="note_translation_action">Translate</string>
+    <string name="note_translation_translating">Translating…</string>
+    <string name="note_translation_show_original">Show original</string>
+    <string name="note_translation_show_translation">Show translation</string>
+    <string name="note_translation_failed">Couldn\'t translate this note.</string>
+    <string name="note_translation_retry">Retry</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1881,4 +1881,12 @@
     <string name="note_translation_already_in_target">This note is already in your language.</string>
     <string name="note_translation_via_on_device">Translated on this device</string>
     <string name="note_translation_via_network">Translated via network (LibreTranslate)</string>
+    <string name="settings_content_display_note_translation">Enable note translation</string>
+    <string name="settings_content_display_note_translation_hint">Show a Translate control under notes. Uses on-device translation when available, with LibreTranslate fallback.</string>
+    <string name="settings_content_display_translation_endpoint">LibreTranslate base URL</string>
+    <string name="settings_content_display_translation_endpoint_hint">Self-hosted instances are recommended for privacy. Default is libretranslate.com.</string>
+    <string name="settings_content_display_translation_api_key">LibreTranslate API key (optional)</string>
+    <string name="settings_content_display_translation_language">Target language (ISO 639-1)</string>
+    <string name="settings_content_display_translation_language_hint">Examples: en, es, de, fr, zh. Defaults to your device language.</string>
+    <string name="settings_content_display_translation_section">Note translation</string>
 </resources>

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -74,6 +74,29 @@ class NoteTextSanitizerTest {
     }
 
     @Test
+    fun shouldOfferTranslation_hidesTokenOnlyNotes() {
+        val tokenOnly =
+            "https://example.com/a/b/c/d/e/f npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+        assertFalse(shouldOfferTranslation(tokenOnly))
+    }
+
+    @Test
+    fun normalizeBaseUrl_stripsTranslatePath() {
+        assertEquals(
+            "https://libretranslate.example",
+            LibreTranslateClient.normalizeBaseUrl("https://libretranslate.example/translate"),
+        )
+        assertEquals(
+            "https://libretranslate.example",
+            LibreTranslateClient.normalizeBaseUrl("https://libretranslate.example/"),
+        )
+        assertEquals(
+            LibreTranslateClient.DEFAULT_BASE_URL,
+            LibreTranslateClient.normalizeBaseUrl(""),
+        )
+    }
+
+    @Test
     fun protect_onDeviceStylePlaceholdersSurviveRestore() {
         // On-device TranslationManager may rewrite unicode brackets to ASCII.
         val input = "hola https://example.com/x npub1abcxyzdeadbeef fin"

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -72,4 +72,16 @@ class NoteTextSanitizerTest {
         assertFalse(shouldOfferTranslation("123456789012345"))
         assertTrue(shouldOfferTranslation("This note is long enough to translate."))
     }
+
+    @Test
+    fun protect_onDeviceStylePlaceholdersSurviveRestore() {
+        // On-device TranslationManager may rewrite unicode brackets to ASCII.
+        val input = "hola https://example.com/x npub1abcxyzdeadbeef fin"
+        val protected = NoteTextSanitizer.protect(input)
+        val mangledByProvider = protected.text
+            .replace("⟦", "[")
+            .replace("⟧", "]")
+        val restored = NoteTextSanitizer.restore(mangledByProvider, protected.tokens)
+        assertEquals(input, restored)
+    }
 }

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -7,13 +7,15 @@ import org.junit.Test
 
 class NoteTextSanitizerTest {
     @Test
-    fun protectAndRestore_keepsNostrAndUrls() {
+    fun protectAndRestore_keepsNostrUrlsInvoicesAndBc1() {
         val input =
-            "hola nostr:npub1abcxyzdeadbeef https://example.com/x #nostr lnbc1testinvoice :smile:"
+            "hola nostr:npub1abcxyzdeadbeef https://example.com/x #nostr lnbc1testinvoice " +
+                "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh :smile:"
         val protected = NoteTextSanitizer.protect(input)
         assertTrue(protected.text.contains("⟦T"))
         assertFalse(protected.text.contains("https://example.com"))
-        // Simulate a translator that leaves placeholders intact
+        assertFalse(protected.text.contains("bc1qxy"))
+        assertFalse(protected.text.contains("lnbc1testinvoice"))
         val restored = NoteTextSanitizer.restore(protected.text, protected.tokens)
         assertEquals(input, restored)
     }
@@ -25,5 +27,21 @@ class NoteTextSanitizerTest {
         assertEquals(2, protected.tokens.size)
         assertEquals("https://a.test", protected.tokens[0])
         assertEquals("https://b.test", protected.tokens[1])
+    }
+
+    @Test
+    fun restore_toleratesProvidersThatDropUnicodeBrackets() {
+        val tokens = listOf("https://example.com", "npub1abcxyzdeadbeef")
+        val mangled = "hello [T0] and [T1] end"
+        val restored = NoteTextSanitizer.restore(mangled, tokens)
+        assertEquals("hello https://example.com and npub1abcxyzdeadbeef end", restored)
+    }
+
+    @Test
+    fun protect_coversNrelayBech32() {
+        val input = "relay nrelay1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq here"
+        val protected = NoteTextSanitizer.protect(input)
+        assertFalse(protected.text.contains("nrelay1"))
+        assertEquals(input, NoteTextSanitizer.restore(protected.text, protected.tokens))
     }
 }

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -55,6 +55,18 @@ class NoteTextSanitizerTest {
     }
 
     @Test
+    fun protect_coversBolt12OfferLnurlCashuAndLightningUri() {
+        val input =
+            "offer lno1offerxyz invoice lightning:lnbc1viauri lnurl1abc cashuAabc123 end"
+        val protected = NoteTextSanitizer.protect(input)
+        assertFalse(protected.text.contains("lno1offer"))
+        assertFalse(protected.text.contains("lightning:"))
+        assertFalse(protected.text.contains("lnurl1"))
+        assertFalse(protected.text.contains("cashuA"))
+        assertEquals(input, NoteTextSanitizer.restore(protected.text, protected.tokens))
+    }
+
+    @Test
     fun shouldOfferTranslation_requiresLengthAndLetters() {
         assertFalse(shouldOfferTranslation("hi"))
         assertFalse(shouldOfferTranslation("123456789012345"))

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -1,0 +1,29 @@
+package net.primal.android.notes.feed.note.translation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NoteTextSanitizerTest {
+    @Test
+    fun protectAndRestore_keepsNostrAndUrls() {
+        val input =
+            "hola nostr:npub1abcxyzdeadbeef https://example.com/x #nostr lnbc1testinvoice :smile:"
+        val protected = NoteTextSanitizer.protect(input)
+        assertTrue(protected.text.contains("⟦T"))
+        assertFalse(protected.text.contains("https://example.com"))
+        // Simulate a translator that leaves placeholders intact
+        val restored = NoteTextSanitizer.restore(protected.text, protected.tokens)
+        assertEquals(input, restored)
+    }
+
+    @Test
+    fun protect_extractsMultipleTokensInOrder() {
+        val input = "see https://a.test and https://b.test"
+        val protected = NoteTextSanitizer.protect(input)
+        assertEquals(2, protected.tokens.size)
+        assertEquals("https://a.test", protected.tokens[0])
+        assertEquals("https://b.test", protected.tokens[1])
+    }
+}

--- a/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
+++ b/app/src/test/kotlin/net/primal/android/notes/feed/note/translation/NoteTextSanitizerTest.kt
@@ -44,4 +44,20 @@ class NoteTextSanitizerTest {
         assertFalse(protected.text.contains("nrelay1"))
         assertEquals(input, NoteTextSanitizer.restore(protected.text, protected.tokens))
     }
+
+    @Test
+    fun protect_coversMentionsAndHashtags() {
+        val input = "hello @alice and #nostr world"
+        val protected = NoteTextSanitizer.protect(input)
+        assertFalse(protected.text.contains("@alice"))
+        assertFalse(protected.text.contains("#nostr"))
+        assertEquals(input, NoteTextSanitizer.restore(protected.text, protected.tokens))
+    }
+
+    @Test
+    fun shouldOfferTranslation_requiresLengthAndLetters() {
+        assertFalse(shouldOfferTranslation("hi"))
+        assertFalse(shouldOfferTranslation("123456789012345"))
+        assertTrue(shouldOfferTranslation("This note is long enough to translate."))
+    }
 }


### PR DESCRIPTION
## Summary
Inline note translation for #1055 with a **hybrid** pipeline:

1. **On-device first** (API 31+): Android `TranslationManager` / language detection — private, no network when models are available
2. **LibreTranslate fallback**: when on-device is unavailable or fails (older OS, missing language packs)
3. **Token sanitizer** (both paths): protects `nostr:` / bech32 (incl. `nrelay`) / URLs / invoices / bolt12 (`lno1`) / LNURL / cashu / `lightning:` / `bc1` / hashtags / `@mentions` / shortcodes; restores ASCII-mangled placeholders
4. **Settings** (Content Display): enable toggle, LibreTranslate base URL, optional API key, target language
5. **Endpoint normalize**: base URL or full `/translate` path (no double path)
6. **Session cache**: in-process LRU for network translations
7. **Offer gating**: hide Translate on short / non-letter / **token-only** notes
8. **Already-in-target**: calm info state (not a red error)

## Why this PR
Compared with open #1094 (on-device only):

| | **This PR (#1095)** | #1094 |
|---|---|---|
| Pre-API 31 devices | LibreTranslate fallback | Hidden |
| Missing language packs | Network fallback | Unavailable |
| LibreTranslate / self-host | Settings + client | No |
| Token safety (invoices, npubs, cashu, bc1) | Both paths | None (raw text to TranslationManager) |
| Issue options (API key / self-host) | Covered | On-device only |
| Unit tests for sanitizer | Yes | Controls smoke only |

Matches the issue's preferred approaches: on-device privacy when possible, plus self-hosted LibreTranslate and identifier safety so Lightning invoices and npubs are not mangled.

## Test plan
- [x] Unit tests for `NoteTextSanitizer` (round-trip, bc1, nrelay, mentions, bolt12/lnurl/cashu, mangled placeholders, offer rules, endpoint normalize)
- [ ] Manual: Translate on API 31+ with on-device packs → caption "Translated on this device"; `npub`/`https`/`bc1` intact
- [ ] Manual: Force fallback (unsupported language / pre-S emulator) → LibreTranslate path
- [ ] Manual: Content Display → Note translation settings; paste full `/translate` URL and confirm normalize
- [ ] Manual: Short / token-only notes do not show Translate
- [ ] Manual: Already-in-target shows info (not red error)

Closes #1055