### PR TITLE
feat: translate notes to user's preferred language (#1055)

### DIFF
--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/FeedNoteCard.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/FeedNoteCard.kt
@@ -76,6 +76,7 @@ import net.primal.android.notes.feed.note.ui.FeedNoteHeader
 import net.primal.android.notes.feed.note.ui.NoteContent
 import net.primal.android.notes.feed.note.ui.NoteDropdownMenuIcon
 import net.primal.android.notes.feed.note.ui.NoteSurfaceCard
+import net.primal.android.notes.feed.note.ui.NoteTranslate
 import net.primal.android.notes.feed.note.ui.RepostedNotice
 import net.primal.android.notes.feed.note.ui.events.NoteCallbacks
 import net.primal.android.notes.feed.zaps.ZapPollBottomSheet
@@ -608,6 +609,16 @@ private fun FeedNote(
                     onVideoSoundToggle = onVideoSoundToggle,
                     onPollOptionSelected = onPollOptionSelected,
                 )
+
+                if (data.kind == NostrEventKind.ShortTextNote.value && data.content.isNotBlank()) {
+                    NoteTranslate(
+                        modifier = Modifier
+                            .padding(horizontal = if (fullWidthContent && !forceContentIndent) 10.dp else 8.dp)
+                            .padding(start = contentIndentDp),
+                        noteId = data.postId,
+                        content = data.content,
+                    )
+                }
 
                 if (isFeedLayout) {
                     Box(modifier = Modifier.padding(start = contentIndentDp)) {

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/MediaFeedCard.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/MediaFeedCard.kt
@@ -94,6 +94,7 @@ import net.primal.android.notes.feed.model.asNeventString
 import net.primal.android.notes.feed.note.NoteContract.UiEvent
 import net.primal.android.notes.feed.note.ui.FeedNoteHeader
 import net.primal.android.notes.feed.note.ui.NoteDropdownMenuIcon
+import net.primal.android.notes.feed.note.ui.NoteTranslate
 import net.primal.android.notes.feed.note.ui.attachment.NoteAttachmentVideoPreview
 import net.primal.android.notes.feed.note.ui.attachment.findMediaFeedCardMediaSize
 import net.primal.android.notes.feed.note.ui.events.MediaClickEvent
@@ -302,6 +303,7 @@ private fun MediaFeedCardBody(
         Spacer(modifier = Modifier.height(MediumSpacing))
 
         MediaFeedContentSection(
+            noteId = data.postId,
             authorName = data.authorName,
             content = data.content,
             hashtags = data.hashtags,
@@ -542,6 +544,7 @@ private fun PageIndicatorDots(pageCount: Int, currentPage: Int) {
 
 @Composable
 private fun MediaFeedContentSection(
+    noteId: String,
     authorName: String,
     content: String,
     hashtags: List<String>,
@@ -602,6 +605,14 @@ private fun MediaFeedContentSection(
                 modifier = Modifier.clickable { onExpandClick() },
                 style = contentTextStyle,
                 color = AppTheme.extraColorScheme.onSurfaceVariantAlt2,
+            )
+        }
+
+        if (content.isNotBlank()) {
+            NoteTranslate(
+                modifier = Modifier.padding(top = 8.dp),
+                noteId = noteId,
+                content = content,
             )
         }
 

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslate.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslate.kt
@@ -1,0 +1,128 @@
+package net.primal.android.notes.feed.note.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import net.primal.android.R
+import net.primal.android.theme.AppTheme
+
+@Composable
+fun NoteTranslate(
+    modifier: Modifier = Modifier,
+    noteId: String,
+    content: String,
+) {
+    if (content.isBlank()) return
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var translation by remember(noteId) { mutableStateOf<TranslationResult?>(null) }
+    var translating by remember(noteId) { mutableStateOf(false) }
+    var failed by remember(noteId) { mutableStateOf(false) }
+
+    val translate = {
+        if (!translating) {
+            val target = TranslationPreferences.getTranslateLanguage(context)
+            val cached = NoteTranslator.getCachedTranslation(noteId, target)
+            if (cached != null) {
+                translation = cached
+            } else {
+                translating = true
+                failed = false
+                scope.launch {
+                    val result = NoteTranslator.translateNoteContent(content, target)
+                    translating = false
+                    if (result != null) {
+                        NoteTranslator.cacheTranslation(noteId, result)
+                        translation = result
+                    } else {
+                        failed = true
+                    }
+                }
+            }
+        }
+    }
+
+    val translated = translation
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        when {
+            translated != null -> {
+                Text(
+                    text = translated.text,
+                    style = AppTheme.typography.bodyMedium,
+                    color = AppTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = stringResource(
+                            id = if (translated.engine == TranslationEngine.GOOGLE) {
+                                R.string.note_translated_by_google
+                            } else {
+                                R.string.note_translated_by_libretranslate
+                            },
+                        ),
+                        style = AppTheme.typography.bodySmall,
+                        color = AppTheme.extraColorScheme.onSurfaceVariantAlt1,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    TextButton(
+                        onClick = {
+                            translation = null
+                            failed = false
+                        },
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.note_show_original),
+                            style = AppTheme.typography.bodySmall,
+                            color = AppTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
+
+            failed -> {
+                Text(
+                    text = stringResource(id = R.string.note_translation_unavailable),
+                    style = AppTheme.typography.bodySmall,
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt1,
+                )
+            }
+
+            else -> {
+                TextButton(
+                    onClick = translate,
+                    enabled = !translating,
+                ) {
+                    Text(
+                        text = stringResource(
+                            id = if (translating) R.string.note_translating else R.string.note_translate,
+                        ),
+                        style = AppTheme.typography.bodySmall,
+                        color = AppTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslation.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteTranslation.kt
@@ -1,0 +1,204 @@
+package net.primal.android.notes.feed.note.ui
+
+import android.content.Context
+import java.net.URLEncoder
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+// Translation of note content into the user's preferred language.
+//
+// Uses free, keyless public translation endpoints, so no API key is required:
+// the public LibreTranslate instances are tried first, and, if none of them is
+// reachable, we fall back to the free Google Translate endpoint
+// (translate.googleapis.com), which requires no key either.
+
+enum class TranslationEngine { LIBRETRANSLATE, GOOGLE }
+
+data class TranslationResult(
+    val text: String,
+    val engine: TranslationEngine,
+    val target: String,
+)
+
+data class TranslationLanguage(
+    val code: String,
+    val name: String,
+)
+
+// A curated list of the most common target languages.
+// Codes are ISO 639-1 (LibreTranslate style); Google-specific variants
+// (zh-Hans, nb) are mapped to their Google equivalents when used.
+val TRANSLATION_LANGUAGES = listOf(
+    TranslationLanguage("en", "English"),
+    TranslationLanguage("es", "Spanish"),
+    TranslationLanguage("fr", "French"),
+    TranslationLanguage("de", "German"),
+    TranslationLanguage("it", "Italian"),
+    TranslationLanguage("pt", "Portuguese"),
+    TranslationLanguage("nl", "Dutch"),
+    TranslationLanguage("ru", "Russian"),
+    TranslationLanguage("uk", "Ukrainian"),
+    TranslationLanguage("pl", "Polish"),
+    TranslationLanguage("cs", "Czech"),
+    TranslationLanguage("sk", "Slovak"),
+    TranslationLanguage("sv", "Swedish"),
+    TranslationLanguage("nb", "Norwegian"),
+    TranslationLanguage("da", "Danish"),
+    TranslationLanguage("fi", "Finnish"),
+    TranslationLanguage("el", "Greek"),
+    TranslationLanguage("tr", "Turkish"),
+    TranslationLanguage("ar", "Arabic"),
+    TranslationLanguage("he", "Hebrew"),
+    TranslationLanguage("hi", "Hindi"),
+    TranslationLanguage("bn", "Bengali"),
+    TranslationLanguage("th", "Thai"),
+    TranslationLanguage("vi", "Vietnamese"),
+    TranslationLanguage("id", "Indonesian"),
+    TranslationLanguage("ja", "Japanese"),
+    TranslationLanguage("ko", "Korean"),
+    TranslationLanguage("zh-Hans", "Chinese (Simplified)"),
+)
+
+private const val PREFS_NAME = "translation"
+private const val KEY_TRANSLATE_LANG = "translate_lang"
+
+private val LIBRETRANSLATE_INSTANCES = listOf(
+    "https://libretranslate.com/translate",
+    "https://translate.terraprint.co/translate",
+    "https://libretranslate.pussthecat.org/translate",
+    "https://lt.vern.cc/translate",
+)
+
+private const val GOOGLE_TRANSLATE_URL = "https://translate.googleapis.com/translate_a/single"
+
+// In-memory cache of translated notes: noteId -> last translation result
+// (kept together with the target language it was translated into).
+private val translationCache = mutableMapOf<String, TranslationResult>()
+
+private fun stripRegion(lang: String) = lang.substringBefore('-').lowercase(Locale.ROOT)
+
+fun defaultTranslateLanguage(): String {
+    val deviceLang = stripRegion(Locale.getDefault().language)
+    val normalized = when (deviceLang) {
+        "zh" -> "zh-Hans"
+        "no" -> "nb"
+        else -> deviceLang
+    }
+    return if (TRANSLATION_LANGUAGES.any { it.code == normalized }) normalized else "en"
+}
+
+object TranslationPreferences {
+
+    fun getTranslateLanguage(context: Context): String {
+        val stored = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_TRANSLATE_LANG, null)
+        return if (stored != null && TRANSLATION_LANGUAGES.any { it.code == stored }) {
+            stored
+        } else {
+            defaultTranslateLanguage()
+        }
+    }
+
+    fun setTranslateLanguage(context: Context, language: String) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_TRANSLATE_LANG, language)
+            .apply()
+    }
+}
+
+private fun toGoogleTarget(target: String): String = when (target) {
+    "zh-Hans" -> "zh-CN"
+    "nb" -> "no"
+    else -> target
+}
+
+object NoteTranslator {
+
+    private val httpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .build()
+    }
+
+    fun getCachedTranslation(noteId: String, target: String): TranslationResult? =
+        translationCache[noteId]?.takeIf { it.target == target }
+
+    fun cacheTranslation(noteId: String, result: TranslationResult) {
+        translationCache[noteId] = result
+    }
+
+    suspend fun translateNoteContent(text: String, target: String): TranslationResult? =
+        withContext(Dispatchers.IO) {
+            translateViaLibreTranslate(text, target) ?: translateViaGoogle(text, target)
+        }
+
+    private fun translateViaLibreTranslate(q: String, target: String): TranslationResult? {
+        val body = JSONObject()
+            .put("q", q)
+            .put("source", "auto")
+            .put("target", target)
+            .put("format", "text")
+            .toString()
+            .toRequestBody("application/json".toMediaType())
+
+        for (url in LIBRETRANSLATE_INSTANCES) {
+            try {
+                val request = Request.Builder().url(url).post(body).build()
+                httpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        return@use
+                    }
+                    val json = JSONObject(response.body?.string().orEmpty())
+                    val translatedText = json.optString("translatedText")
+                    if (translatedText.isNotBlank()) {
+                        return TranslationResult(
+                            text = translatedText,
+                            engine = TranslationEngine.LIBRETRANSLATE,
+                            target = target,
+                        )
+                    }
+                }
+            } catch (_: Exception) {
+                // Instance is unreachable; try the next one.
+            }
+        }
+        return null
+    }
+
+    private fun translateViaGoogle(q: String, target: String): TranslationResult? {
+        val url = "$GOOGLE_TRANSLATE_URL?client=gtx&sl=auto&tl=${toGoogleTarget(target)}&dt=t&q=${
+            URLEncoder.encode(q, "UTF-8")
+        }"
+        return try {
+            val request = Request.Builder().url(url).build()
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    return null
+                }
+                val json = JSONArray(response.body?.string().orEmpty())
+                val translatedText = json.optJSONArray(0)?.optJSONArray(0)?.optString(0).orEmpty()
+                if (translatedText.isNotBlank()) {
+                    TranslationResult(
+                        text = translatedText,
+                        engine = TranslationEngine.GOOGLE,
+                        target = target,
+                    )
+                } else {
+                    null
+                }
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsContract.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsContract.kt
@@ -7,11 +7,13 @@ interface AppearanceSettingsContract {
     data class UiState(
         val selectedThemeName: String? = null,
         val themes: List<PrimalTheme> = emptyList(),
+        val translationLanguage: String? = null,
     )
 
     sealed class UiEvent {
         data class ChangeTheme(val themeName: String) : UiEvent()
         data class ToggleAutoAdjustDarkTheme(val enabled: Boolean, val isSystemInDarkTheme: Boolean) : UiEvent()
         data class ChangeContentAppearance(val contentAppearance: ContentAppearance) : UiEvent()
+        data class ChangeTranslationLanguage(val language: String) : UiEvent()
     }
 }

--- a/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsScreen.kt
@@ -18,9 +18,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -73,6 +76,8 @@ import net.primal.android.core.compose.settings.SettingsItem
 import net.primal.android.notes.feed.model.EventStatsUi
 import net.primal.android.notes.feed.model.FeedPostUi
 import net.primal.android.notes.feed.note.FeedNoteCard
+import net.primal.android.notes.feed.note.ui.TRANSLATION_LANGUAGES
+import net.primal.android.notes.feed.note.ui.defaultTranslateLanguage
 import net.primal.android.settings.appearance.AppearanceSettingsContract.UiEvent
 import net.primal.android.theme.AppTheme
 import net.primal.android.theme.domain.PrimalTheme
@@ -163,6 +168,16 @@ fun AppearanceSettingsScreen(
                         .padding(horizontal = 16.dp, vertical = 16.dp),
                     onNoteAppearanceChanged = {
                         eventPublisher(UiEvent.ChangeContentAppearance(contentAppearance = it))
+                    },
+                )
+
+                PrimalDivider(modifier = Modifier.padding(horizontal = 8.dp))
+
+                TranslationLanguageSection(
+                    modifier = Modifier.fillMaxWidth(),
+                    selectedLanguageCode = state.translationLanguage,
+                    onLanguageChange = {
+                        eventPublisher(UiEvent.ChangeTranslationLanguage(language = it))
                     },
                 )
 
@@ -506,6 +521,89 @@ private fun NotePreviewSection(modifier: Modifier) {
             colors = CardDefaults.cardColors(
                 containerColor = AppTheme.extraColorScheme.surfaceVariantAlt2,
             ),
+        )
+    }
+}
+
+@Composable
+private fun TranslationLanguageSection(
+    modifier: Modifier = Modifier,
+    selectedLanguageCode: String?,
+    onLanguageChange: (String) -> Unit,
+) {
+    var showLanguageDialog by remember { mutableStateOf(false) }
+
+    val effectiveLanguageCode = selectedLanguageCode ?: defaultTranslateLanguage()
+    val selectedLanguageName = TRANSLATION_LANGUAGES
+        .firstOrNull { it.code == effectiveLanguageCode }
+        ?.name
+        ?: effectiveLanguageCode
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+            text = stringResource(id = R.string.settings_appearance_translation_section_title).uppercase(),
+            fontWeight = FontWeight.W500,
+            fontSize = 14.sp,
+            lineHeight = 16.sp,
+        )
+
+        SettingsItem(
+            headlineText = stringResource(id = R.string.settings_appearance_translation_language),
+            supportText = stringResource(id = R.string.settings_appearance_translation_language_hint),
+            trailingContent = {
+                Text(
+                    text = selectedLanguageName,
+                    style = AppTheme.typography.bodyMedium,
+                    color = AppTheme.extraColorScheme.onSurfaceVariantAlt1,
+                )
+            },
+            onClick = { showLanguageDialog = true },
+        )
+    }
+
+    if (showLanguageDialog) {
+        AlertDialog(
+            onDismissRequest = { showLanguageDialog = false },
+            title = {
+                Text(text = stringResource(id = R.string.settings_appearance_translation_language))
+            },
+            text = {
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                ) {
+                    TRANSLATION_LANGUAGES.forEach { language ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onLanguageChange(language.code)
+                                    showLanguageDialog = false
+                                }
+                                .padding(vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = language.name,
+                                modifier = Modifier.weight(1f),
+                                style = AppTheme.typography.bodyMedium,
+                            )
+                            if (language.code == effectiveLanguageCode) {
+                                Icon(
+                                    imageVector = Icons.Filled.Check,
+                                    contentDescription = null,
+                                    tint = AppTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
         )
     }
 }

--- a/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsViewModel.kt
+++ b/app/src/main/kotlin/net/primal/android/settings/appearance/AppearanceSettingsViewModel.kt
@@ -1,14 +1,17 @@
 package net.primal.android.settings.appearance
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.launch
+import net.primal.android.notes.feed.note.ui.TranslationPreferences
 import net.primal.android.theme.active.ActiveThemeStore
 import net.primal.android.theme.domain.PrimalTheme
 import net.primal.android.theme.findThemeOrDefault
@@ -18,6 +21,7 @@ import net.primal.android.user.repository.UserRepository
 
 class AppearanceSettingsViewModel @AssistedInject constructor(
     @Assisted private var lastUserPickedPrimalTheme: PrimalTheme,
+    @ApplicationContext private val context: Context,
     private val activeThemeStore: ActiveThemeStore,
     private val activeAccountStore: ActiveAccountStore,
     private val userRepository: UserRepository,
@@ -38,6 +42,9 @@ class AppearanceSettingsViewModel @AssistedInject constructor(
         initThemes()
         observeActiveThemeStore()
         observeEvents()
+        setState {
+            copy(translationLanguage = TranslationPreferences.getTranslateLanguage(context))
+        }
     }
 
     private fun initThemes() =
@@ -77,6 +84,11 @@ class AppearanceSettingsViewModel @AssistedInject constructor(
 
                     is AppearanceSettingsContract.UiEvent.ChangeContentAppearance -> {
                         setContentAppearance(contentAppearance = event.contentAppearance)
+                    }
+
+                    is AppearanceSettingsContract.UiEvent.ChangeTranslationLanguage -> {
+                        TranslationPreferences.setTranslateLanguage(context, event.language)
+                        setState { copy(translationLanguage = event.language) }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1061,6 +1061,16 @@
     <string name="settings_appearance_auto_adjust_dark_mode_hint">Automatically set dark theme based on your device Display settings.</string>
     <string name="settings_appearance_font_section_title">Font</string>
     <string name="settings_appearance_note_preview_section_title">Preview</string>
+    <string name="settings_appearance_translation_section_title">Translation</string>
+    <string name="settings_appearance_translation_language">Translation language</string>
+    <string name="settings_appearance_translation_language_hint">Notes are translated into this language</string>
+
+    <string name="note_translate">Translate</string>
+    <string name="note_translating">Translating…</string>
+    <string name="note_show_original">Show original</string>
+    <string name="note_translated_by_libretranslate">Translated by LibreTranslate</string>
+    <string name="note_translated_by_google">Translated by Google Translate</string>
+    <string name="note_translation_unavailable">Translation is unavailable right now. Please try again later.</string>
 
     <string name="settings_content_display_title">Content Display</string>
     <string name="settings_content_display_auto_play_videos">Auto play videos</string>


### PR DESCRIPTION
Closes #1055 — Translate notes to user's preferred language

Adds a **Translate** button on notes (feed, thread, single, media feeds). Uses free keyless translation (LibreTranslate public instances → Google Translate fallback, no API key required), a language preference in Settings → Appearance → Translation (28 languages, defaults to device locale), and an in-memory per-note cache so toggling is instant. Translated notes show attribution + "Show original".

Mirrors the web implementation (primal-web-app #212).
