### PR TITLE
Add note translation action

### DIFF
--- a/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteDropdownMenu.kt
+++ b/app/src/main/kotlin/net/primal/android/notes/feed/note/ui/NoteDropdownMenu.kt
@@ -1,5 +1,8 @@
 package net.primal.android.notes.feed.note.ui
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -48,6 +51,7 @@ import net.primal.domain.nostr.Nevent
 import net.primal.domain.nostr.Nip19TLV.toNeventString
 import net.primal.domain.nostr.NostrEventKind
 import net.primal.domain.nostr.utils.withNostrPrefix
+import java.util.Locale
 
 @Composable
 fun NoteDropdownMenuIcon(
@@ -187,6 +191,16 @@ fun NoteDropdownMenuIcon(
                 },
             )
             DropdownPrimalMenuItem(
+                trailingIconVector = PrimalIcons.ContextCopyNoteText,
+                text = stringResource(
+                    id = if (isPoll) R.string.feed_context_translate_poll else R.string.feed_context_translate_note,
+                ),
+                onClick = {
+                    context.openGoogleTranslate(text = noteContent)
+                    menuVisible = false
+                },
+            )
+            DropdownPrimalMenuItem(
                 trailingIconVector = PrimalIcons.ContextCopyNoteId,
                 text = stringResource(
                     id = if (isPoll) R.string.feed_context_copy_poll_id else R.string.feed_context_copy_note_id,
@@ -271,4 +285,22 @@ fun NoteDropdownMenuIcon(
             }
         }
     }
+}
+
+private fun Context.openGoogleTranslate(text: String) {
+    val noteText = text.trim()
+    if (noteText.isEmpty()) return
+
+    val targetLanguage = Locale.getDefault().language.ifBlank { "en" }
+    val translateUri = Uri.Builder()
+        .scheme("https")
+        .authority("translate.google.com")
+        .path("/")
+        .appendQueryParameter("sl", "auto")
+        .appendQueryParameter("tl", targetLanguage)
+        .appendQueryParameter("text", noteText)
+        .appendQueryParameter("op", "translate")
+        .build()
+
+    startActivity(Intent(Intent.ACTION_VIEW, translateUri))
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,8 @@
     <string name="feed_context_bookmark_removed">Note removed from your bookmarks.</string>
     <string name="feed_context_copy_note_text">Copy Note Text</string>
     <string name="feed_context_copy_poll_question">Copy Poll Question</string>
+    <string name="feed_context_translate_note">Translate Note</string>
+    <string name="feed_context_translate_poll">Translate Poll</string>
     <string name="feed_context_copy_note_id">Copy Note ID</string>
     <string name="feed_context_copy_poll_id">Copy Poll ID</string>
     <string name="feed_context_copy_raw_data">Copy Raw Data</string>


### PR DESCRIPTION
## Summary
- Adds a Translate Note/Translate Poll action to the note dropdown menu
- Opens Google Translate with source language auto-detection and the device locale as the target language
- Keeps translation user-triggered only, with no background requests or API key requirement

Fixes #1055

## Testing
- Attempted `./gradlew.bat :app:compileDebugKotlin`
- Initial run failed because Gradle could not download the required JDK 21 toolchain from foojay
- Retried with a local Temurin JDK 21 toolchain; the task did not finish within the available local time window before submission